### PR TITLE
feat(scurity): implement security search/filter, remove header search…

### DIFF
--- a/app/securities/page.tsx
+++ b/app/securities/page.tsx
@@ -1,117 +1,75 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { ArrowUpRight, AlertCircle, LineChart, Search } from "lucide-react";
+import { ArrowUpRight, AlertCircle, LineChart, Search, Filter } from "lucide-react";
 import Link from "next/link";
 import { ProtectedRoute } from '@/components/auth/protected-route';
-
-interface Security {
-  ticker: string;
-  name: string;
-  sector: string;
-  price: number;
-  yield: number;
-  sma200: "above" | "below";
-  tags: string[];
-}
-
-const securities: Security[] = [
-  {
-    ticker: "AAPL",
-    name: "Apple Inc.",
-    sector: "Technology",
-    price: 188.32,
-    yield: 0.5,
-    sma200: "above",
-    tags: ["Growth", "Dividend Growth"],
-  },
-  {
-    ticker: "MSFT",
-    name: "Microsoft Corp.",
-    sector: "Technology",
-    price: 410.78,
-    yield: 0.8,
-    sma200: "below",
-    tags: ["Growth", "Large Cap"],
-  },
-  {
-    ticker: "JNJ",
-    name: "Johnson & Johnson",
-    sector: "Healthcare",
-    price: 156.76,
-    yield: 3.2,
-    sma200: "below",
-    tags: ["Dividend Aristocrat", "Defensive"],
-  },
-  {
-    ticker: "PG",
-    name: "Procter & Gamble Co.",
-    sector: "Consumer Staples",
-    price: 162.55,
-    yield: 2.4,
-    sma200: "above",
-    tags: ["Dividend King", "Defensive"],
-  },
-  {
-    ticker: "KO",
-    name: "Coca-Cola Co.",
-    sector: "Consumer Staples",
-    price: 60.33,
-    yield: 3.0,
-    sma200: "below",
-    tags: ["Dividend Aristocrat", "Defensive"],
-  },
-  {
-    ticker: "ABBV",
-    name: "AbbVie Inc.",
-    sector: "Healthcare",
-    price: 165.42,
-    yield: 3.8,
-    sma200: "below",
-    tags: ["Dividend Growth", "Healthcare"],
-  },
-  {
-    ticker: "VZ",
-    name: "Verizon Communications",
-    sector: "Communication Services",
-    price: 41.35,
-    yield: 6.8,
-    sma200: "above",
-    tags: ["High Yield", "Telecom"],
-  },
-  {
-    ticker: "O",
-    name: "Realty Income Corp.",
-    sector: "Real Estate",
-    price: 53.67,
-    yield: 5.4,
-    sma200: "above",
-    tags: ["REIT", "Monthly Dividend"],
-  },
-  {
-    ticker: "PEP",
-    name: "PepsiCo Inc.",
-    sector: "Consumer Staples",
-    price: 172.35,
-    yield: 2.9,
-    sma200: "below",
-    tags: ["Consumer Defensive", "Dividend Growth"],
-  },
-  {
-    ticker: "XOM",
-    name: "Exxon Mobil Corp.",
-    sector: "Energy",
-    price: 107.89,
-    yield: 3.5,
-    sma200: "below",
-    tags: ["Energy", "Value"],
-  },
-];
+import { securityService, Security } from '@/services/securityService';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { Card, CardContent } from "@/components/ui/card";
+import { useAuth } from '@/lib/auth';
 
 export default function SecuritiesPage() {
+  const [securities, setSecurities] = useState<Security[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filters, setFilters] = useState({
+    sector: 'all',
+    minYield: 0,
+    maxYield: 10,
+    sma200: 'all' as 'above' | 'below' | 'all',
+    sortBy: 'ticker' as 'ticker' | 'name' | 'yield' | 'price',
+    sortOrder: 'asc' as 'asc' | 'desc'
+  });
+  const [showFilters, setShowFilters] = useState(false);
+  const { session } = useAuth();
+
+  useEffect(() => {
+    const fetchSecurities = async () => {
+      if (!session?.access_token) {
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const data = await securityService.searchSecurities(searchQuery, {
+          ...filters,
+          sector: filters.sector === 'all' ? undefined : filters.sector,
+          sma200: filters.sma200 === 'all' ? undefined : filters.sma200
+        });
+        setSecurities(data);
+      } catch (error) {
+        console.error('Error fetching securities:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    const debounceTimer = setTimeout(() => {
+      fetchSecurities();
+    }, 300);
+
+    return () => clearTimeout(debounceTimer);
+  }, [session, searchQuery, filters]);
+
+  const handleSortChange = (value: string) => {
+    const [newSortBy, newSortOrder] = value.split('-');
+    setFilters(prev => ({
+      ...prev,
+      sortBy: newSortBy as 'ticker' | 'name' | 'yield' | 'price',
+      sortOrder: newSortOrder as 'asc' | 'desc'
+    }));
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <ProtectedRoute>
       <div className="space-y-6">
@@ -130,25 +88,116 @@ export default function SecuritiesPage() {
                 type="search"
                 placeholder="Search securities..."
                 className="w-full pl-8"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
               />
             </div>
+            <Button variant="outline" onClick={() => setShowFilters(!showFilters)}>
+              <Filter className="mr-2 h-4 w-4" />
+              Filters
+            </Button>
             <Button>
               <LineChart className="mr-2 h-4 w-4" />
               AI Analyze
             </Button>
           </div>
         </div>
-        
+
+        {showFilters && (
+          <Card>
+            <CardContent className="pt-6">
+              <div className="grid gap-4 md:grid-cols-4">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Sector</label>
+                  <Select
+                    value={filters.sector}
+                    onValueChange={(value) => setFilters(prev => ({ ...prev, sector: value }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="All Sectors" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Sectors</SelectItem>
+                      <SelectItem value="Technology">Technology</SelectItem>
+                      <SelectItem value="Healthcare">Healthcare</SelectItem>
+                      <SelectItem value="Financial">Financial</SelectItem>
+                      <SelectItem value="Consumer">Consumer</SelectItem>
+                      <SelectItem value="Energy">Energy</SelectItem>
+                      <SelectItem value="Utilities">Utilities</SelectItem>
+                      <SelectItem value="Real Estate">Real Estate</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Yield Range</label>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm">{filters.minYield}%</span>
+                    <Slider
+                      value={[filters.minYield, filters.maxYield]}
+                      min={0}
+                      max={10}
+                      step={0.1}
+                      onValueChange={([min, max]) => setFilters(prev => ({ ...prev, minYield: min, maxYield: max }))}
+                      className="flex-1"
+                    />
+                    <span className="text-sm">{filters.maxYield}%</span>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">SMA-200</label>
+                  <Select
+                    value={filters.sma200}
+                    onValueChange={(value) => setFilters(prev => ({ ...prev, sma200: value as 'above' | 'below' | 'all' }))}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="All" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      <SelectItem value="above">Above</SelectItem>
+                      <SelectItem value="below">Below</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">Sort By</label>
+                  <Select
+                    value={`${filters.sortBy}-${filters.sortOrder}`}
+                    onValueChange={handleSortChange}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sort by..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ticker-asc">Ticker (A-Z)</SelectItem>
+                      <SelectItem value="ticker-desc">Ticker (Z-A)</SelectItem>
+                      <SelectItem value="name-asc">Name (A-Z)</SelectItem>
+                      <SelectItem value="name-desc">Name (Z-A)</SelectItem>
+                      <SelectItem value="yield-desc">Highest Yield</SelectItem>
+                      <SelectItem value="yield-asc">Lowest Yield</SelectItem>
+                      <SelectItem value="price-desc">Highest Price</SelectItem>
+                      <SelectItem value="price-asc">Lowest Price</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
         <div className="rounded-md border">
           <Table>
             <TableHeader>
               <TableRow>
                 <TableHead>Ticker</TableHead>
-                <TableHead className="hidden md:table-cell">Name</TableHead>
-                <TableHead className="hidden lg:table-cell">Sector</TableHead>
-                <TableHead>Price</TableHead>
-                <TableHead>Yield</TableHead>
-                <TableHead>Signal</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Sector</TableHead>
+                <TableHead className="text-right">Price</TableHead>
+                <TableHead className="text-right">Yield</TableHead>
+                <TableHead className="text-right">SMA-200</TableHead>
                 <TableHead className="hidden xl:table-cell">Tags</TableHead>
               </TableRow>
             </TableHeader>
@@ -160,21 +209,13 @@ export default function SecuritiesPage() {
                       {security.ticker}
                     </Link>
                   </TableCell>
-                  <TableCell className="hidden md:table-cell">{security.name}</TableCell>
-                  <TableCell className="hidden lg:table-cell">{security.sector}</TableCell>
-                  <TableCell>${security.price.toFixed(2)}</TableCell>
-                  <TableCell>{security.yield.toFixed(1)}%</TableCell>
-                  <TableCell>
-                    <Badge 
-                      variant={security.sma200 === "below" ? "default" : "outline"}
-                      className={security.sma200 === "below" ? "bg-green-600" : ""}
-                    >
-                      {security.sma200 === "below" ? (
-                        <ArrowUpRight className="mr-1 h-3 w-3" />
-                      ) : (
-                        <AlertCircle className="mr-1 h-3 w-3" />
-                      )}
-                      {security.sma200 === "below" ? "Buy" : "Hold"}
+                  <TableCell>{security.name}</TableCell>
+                  <TableCell>{security.sector}</TableCell>
+                  <TableCell className="text-right">${security.price.toFixed(2)}</TableCell>
+                  <TableCell className="text-right">{security.yield.toFixed(2)}%</TableCell>
+                  <TableCell className="text-right">
+                    <Badge variant={security.sma200 === "above" ? "default" : "secondary"}>
+                      {security.sma200 === "above" ? "Above" : "Below"}
                     </Badge>
                   </TableCell>
                   <TableCell className="hidden xl:table-cell">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -44,15 +44,6 @@ export default function Header() {
         </div>
 
         <div className="flex items-center justify-end space-x-4">
-          <div className="relative hidden md:flex">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              type="search"
-              placeholder="Search securities..."
-              className="w-[200px] pl-8 md:w-[260px] lg:w-[320px]"
-            />
-          </div>
-
           {user ? (
             <>
               <Button variant="ghost" size="icon">

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -13,7 +13,6 @@ test.describe('Basic Navigation', () => {
     // Check if header elements are visible
     await expect(page.getByRole('banner')).toBeVisible();
     await expect(page.getByRole('link', { name: 'AI Income Investor' })).toBeVisible();
-    await expect(page.getByRole('searchbox', { name: 'Search securities...' })).toBeVisible();
     
     // Check if sidebar navigation elements are visible
     await expect(page.getByRole('complementary')).toBeVisible();


### PR DESCRIPTION
…, update tests

- Implemented search and filtering for securities (sector, yield, SMA-200, sort) in the securities page
- Added `searchSecurities` method to `securityService`
- Removed the unused search field from the top header for a cleaner UI
- Updated Playwright navigation test to remove assertion for the deleted header search field
- Fixed select filter values to avoid empty string errors