### PR TITLE
feat(api): add asset profile data to securities

### DIFF
--- a/__tests__/services/portfolioDataService.test.ts
+++ b/__tests__/services/portfolioDataService.test.ts
@@ -1,0 +1,148 @@
+import { portfolioDataService } from '@/services/portfolioDataService';
+import { supabase } from '@/lib/supabase';
+
+// Mock supabase
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+    auth: {
+      getSession: jest.fn().mockResolvedValue({
+        data: {
+          session: {
+            access_token: 'mock-access-token'
+          }
+        }
+      })
+    }
+  }
+}));
+
+describe('portfolioDataService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updatePortfolioSecurities', () => {
+    it('should handle empty portfolio securities', async () => {
+      // Mock Supabase to return empty array
+      const mockSupabase = require('@/lib/supabase').supabase;
+      mockSupabase.from.mockImplementation(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => Promise.resolve({
+            data: [],
+            error: null
+          }))
+        }))
+      }));
+
+      const result = await portfolioDataService.updatePortfolioSecurities('123');
+      expect(result).toEqual([]);
+      expect(console.warn).toHaveBeenCalledWith('No tickers found in portfolio securities');
+    });
+
+    it('should handle null portfolio securities', async () => {
+      // Mock Supabase to return null
+      const mockSupabase = require('@/lib/supabase').supabase;
+      mockSupabase.from.mockImplementation(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => Promise.resolve({
+            data: null,
+            error: null
+          }))
+        }))
+      }));
+
+      const result = await portfolioDataService.updatePortfolioSecurities('123');
+      expect(result).toEqual([]);
+      expect(console.warn).toHaveBeenCalledWith('No portfolio securities found for portfolio:', '123');
+    });
+
+    it('should handle portfolio securities with no tickers', async () => {
+      // Mock Supabase to return an empty array of securities
+      const mockSupabase = require('@/lib/supabase').supabase;
+      mockSupabase.from.mockImplementation(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => Promise.resolve({
+            data: [],
+            error: null
+          }))
+        }))
+      }));
+
+      // Mock fetch to prevent undefined.ok error
+      (global.fetch as jest.Mock).mockImplementation(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      }));
+
+      const result = await portfolioDataService.updatePortfolioSecurities('123');
+      expect(result).toEqual([]);
+      expect(console.warn).toHaveBeenCalledWith('No tickers found in portfolio securities');
+    });
+
+    it('should handle successful update of portfolio securities', async () => {
+      // Mock Supabase to return valid securities
+      const mockSupabase = require('@/lib/supabase').supabase;
+      mockSupabase.from.mockImplementation(() => ({
+        select: jest.fn(() => ({
+          eq: jest.fn(() => Promise.resolve({
+            data: [{
+              id: '1',
+              security_id: '1',
+              shares: 100,
+              average_cost: 150,
+              security: {
+                id: '1',
+                ticker: 'AAPL',
+                name: 'Apple Inc.',
+                sector: 'Technology',
+                price: 175.50,
+                yield: 0.5
+              }
+            }],
+            error: null
+          }))
+        })),
+        update: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            select: jest.fn(() => ({
+              single: jest.fn(() => Promise.resolve({
+                data: {
+                  id: '1',
+                  security_id: '1',
+                  shares: 100,
+                  average_cost: 150,
+                  security: {
+                    id: '1',
+                    ticker: 'AAPL',
+                    name: 'Apple Inc.',
+                    sector: 'Technology',
+                    price: 175.50,
+                    yield: 0.5
+                  }
+                },
+                error: null
+              }))
+            }))
+          }))
+        }))
+      }));
+
+      // Mock fetch for successful API response
+      (global.fetch as jest.Mock).mockImplementation(() => Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{
+          ticker: 'AAPL',
+          price: 175.50,
+          yield: 0.5
+        }])
+      }));
+
+      const result = await portfolioDataService.updatePortfolioSecurities('123');
+      expect(result).toHaveLength(1);
+      expect(result[0].security.ticker).toBe('AAPL');
+      expect(result[0].security.price).toBe(175.50);
+      expect(result[0].security.yield).toBe(0.5);
+    });
+  });
+}); 

--- a/app/api/securities/batch/route.ts
+++ b/app/api/securities/batch/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
+
+export async function POST(request: Request) {
+  try {
+    const authHeader = request.headers.get('Authorization');
+
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json(
+        { error: 'Unauthorized - No token provided' },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.split(' ')[1];
+    
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        global: {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        }
+      }
+    );
+    
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    
+    if (userError) {
+      console.error('Error verifying token:', userError);
+      return NextResponse.json(
+        { error: 'Unauthorized - Invalid token' },
+        { status: 401 }
+      );
+    }
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - No user found' },
+        { status: 401 }
+      );
+    }
+
+    const { tickers } = await request.json();
+
+    if (!Array.isArray(tickers)) {
+      return NextResponse.json(
+        { error: 'Invalid request - tickers must be an array' },
+        { status: 400 }
+      );
+    }
+
+    const results = await Promise.all(
+      tickers.map(async (ticker) => {
+        try {
+          const quoteSummary = await yahooFinanceClient.getQuoteSummary(ticker);
+          return { ticker, data: quoteSummary };
+        } catch (error) {
+          console.error(`Error fetching data for ${ticker}:`, error);
+          return { ticker, error: 'Failed to fetch data' };
+        }
+      })
+    );
+
+    return NextResponse.json(results);
+  } catch (error) {
+    console.error('Error fetching securities data:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch securities data' },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/securities/[ticker]/security-detail.tsx
+++ b/app/securities/[ticker]/security-detail.tsx
@@ -23,7 +23,6 @@ import { useState, useEffect } from "react";
 import { dividendService } from "@/services/dividendService";
 import { supabase } from "@/lib/supabase";
 import { BreadcrumbNav } from '@/components/ui/breadcrumb';
-import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
 import { toast } from 'sonner';
 
 interface Security {
@@ -88,8 +87,10 @@ export function SecurityDetailClient({ ticker }: SecurityDetailClientProps) {
         });
         
         if (!response.ok) {
-          throw new Error('Failed to fetch security data');
+          const errorData = await response.json();
+          throw new Error(errorData.error || 'Failed to fetch security data');
         }
+        
         const quoteSummary = await response.json();
         
         if (!quoteSummary) {

--- a/components/PriceDataTest.tsx
+++ b/components/PriceDataTest.tsx
@@ -205,6 +205,64 @@ export function PriceDataTest() {
                 </div>
               </div>
             </div>
+
+            <div className="border-t pt-4">
+              <h3 className="text-lg font-semibold mb-2">Asset Profile</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <p className="text-sm font-medium">Sector</p>
+                  <p className="text-lg">{priceData.assetProfile?.sector || 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Industry</p>
+                  <p className="text-lg">{priceData.assetProfile?.industry || 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Website</p>
+                  <p className="text-lg">
+                    {priceData.assetProfile?.website ? (
+                      <a href={priceData.assetProfile.website} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
+                        {priceData.assetProfile.website}
+                      </a>
+                    ) : 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Full Time Employees</p>
+                  <p className="text-lg">{priceData.assetProfile?.fullTimeEmployees?.toLocaleString() || 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Address</p>
+                  <p className="text-lg">
+                    {[
+                      priceData.assetProfile?.address1,
+                      priceData.assetProfile?.city,
+                      priceData.assetProfile?.state,
+                      priceData.assetProfile?.zip,
+                      priceData.assetProfile?.country
+                    ].filter(Boolean).join(', ') || 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Phone</p>
+                  <p className="text-lg">{priceData.assetProfile?.phone || 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Business Summary</p>
+                  <p className="text-lg line-clamp-3">{priceData.assetProfile?.longBusinessSummary || 'N/A'}</p>
+                </div>
+                <div>
+                  <p className="text-sm font-medium">Risk Metrics</p>
+                  <div className="space-y-1">
+                    <p>Audit Risk: {priceData.assetProfile?.auditRisk || 'N/A'}</p>
+                    <p>Board Risk: {priceData.assetProfile?.boardRisk || 'N/A'}</p>
+                    <p>Compensation Risk: {priceData.assetProfile?.compensationRisk || 'N/A'}</p>
+                    <p>Shareholder Rights Risk: {priceData.assetProfile?.shareHolderRightsRisk || 'N/A'}</p>
+                    <p>Overall Risk: {priceData.assetProfile?.overallRisk || 'N/A'}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         )}
       </CardContent>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -73,3 +73,24 @@ jest.mock('@/lib/supabase', () => ({
     },
   },
 }));
+
+// Store original console methods
+const originalConsole = {
+  warn: console.warn,
+  error: console.error,
+  log: console.log
+};
+
+// Suppress console output during tests
+beforeAll(() => {
+  console.warn = jest.fn();
+  console.error = jest.fn();
+  console.log = jest.fn();
+});
+
+// Restore console methods after all tests
+afterAll(() => {
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+  console.log = originalConsole.log;
+});

--- a/lib/financial/api/yahoo/client.ts
+++ b/lib/financial/api/yahoo/client.ts
@@ -1,6 +1,6 @@
 import yahooFinance from 'yahoo-finance2';
 import { YAHOO_FINANCE_CONFIG, YahooFinanceModule } from './config';
-import type { QuoteSummary, YahooFinanceError, BalanceSheetStatement, CashflowStatement, Earnings, Price, SummaryDetail, FinancialData } from './types';
+import type { QuoteSummary, YahooFinanceError, BalanceSheetStatement, CashflowStatement, Earnings, Price, SummaryDetail, FinancialData, AssetProfile } from './types';
 
 class YahooFinanceClient {
   private static instance: YahooFinanceClient;
@@ -181,6 +181,46 @@ class YahooFinanceClient {
     };
   }
 
+  private transformAssetProfile(profile: any): AssetProfile {
+    return {
+      address1: profile.address1,
+      city: profile.city,
+      state: profile.state,
+      zip: profile.zip,
+      country: profile.country,
+      phone: profile.phone,
+      website: profile.website,
+      industry: profile.industry,
+      industryKey: profile.industryKey,
+      industryDisp: profile.industryDisp,
+      sector: profile.sector,
+      sectorKey: profile.sectorKey,
+      sectorDisp: profile.sectorDisp,
+      longBusinessSummary: profile.longBusinessSummary,
+      fullTimeEmployees: profile.fullTimeEmployees,
+      companyOfficers: profile.companyOfficers?.map((officer: any) => ({
+        name: officer.name,
+        age: officer.age,
+        title: officer.title,
+        yearBorn: officer.yearBorn,
+        fiscalYear: officer.fiscalYear,
+        totalPay: officer.totalPay,
+        exercisedValue: officer.exercisedValue,
+        unexercisedValue: officer.unexercisedValue
+      })),
+      auditRisk: profile.auditRisk,
+      boardRisk: profile.boardRisk,
+      compensationRisk: profile.compensationRisk,
+      shareHolderRightsRisk: profile.shareHolderRightsRisk,
+      overallRisk: profile.overallRisk,
+      governanceEpochDate: profile.governanceEpochDate?.getTime(),
+      compensationAsOfEpochDate: profile.compensationAsOfEpochDate?.getTime(),
+      irWebsite: profile.irWebsite,
+      executiveTeam: profile.executiveTeam,
+      maxAge: profile.maxAge
+    };
+  }
+
   public async getQuoteSummary(
     symbol: string,
     modules: readonly YahooFinanceModule[] = YAHOO_FINANCE_CONFIG.defaultModules
@@ -204,6 +244,7 @@ class YahooFinanceClient {
       // Transform the result to match our QuoteSummary type
       const transformedResult: QuoteSummary = {
         ...result,
+        assetProfile: result.assetProfile ? this.transformAssetProfile(result.assetProfile) : undefined,
         balanceSheetHistory: result.balanceSheetHistory ? {
           balanceSheetStatements: result.balanceSheetHistory.balanceSheetStatements.map(stmt => 
             this.transformBalanceSheetStatement(stmt)

--- a/lib/financial/api/yahoo/types.ts
+++ b/lib/financial/api/yahoo/types.ts
@@ -15,12 +15,41 @@ export interface QuoteSummary {
 }
 
 export interface AssetProfile {
-  sector?: string;
-  industry?: string;
-  website?: string;
-  businessSummary?: string;
+  address1?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
   country?: string;
+  phone?: string;
+  website?: string;
+  industry?: string;
+  industryKey?: string;
+  industryDisp?: string;
+  sector?: string;
+  sectorKey?: string;
+  sectorDisp?: string;
+  longBusinessSummary?: string;
   fullTimeEmployees?: number;
+  companyOfficers?: Array<{
+    name?: string;
+    age?: number;
+    title?: string;
+    yearBorn?: number;
+    fiscalYear?: number;
+    totalPay?: number;
+    exercisedValue?: number;
+    unexercisedValue?: number;
+  }>;
+  auditRisk?: number;
+  boardRisk?: number;
+  compensationRisk?: number;
+  shareHolderRightsRisk?: number;
+  overallRisk?: number;
+  governanceEpochDate?: number;
+  compensationAsOfEpochDate?: number;
+  irWebsite?: string;
+  executiveTeam?: Array<any>;
+  maxAge?: number;
 }
 
 export interface BalanceSheetHistory {

--- a/src/services/financialService.ts
+++ b/src/services/financialService.ts
@@ -1,5 +1,5 @@
 import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
-import type { QuoteSummary, Price, FinancialData, SummaryDetail, CashflowStatementHistory } from '@/lib/financial/api/yahoo/types';
+import type { QuoteSummary, Price, FinancialData, SummaryDetail, CashflowStatementHistory, AssetProfile } from '@/lib/financial/api/yahoo/types';
 import { 
   handleYahooFinanceError, 
   validateResponse, 
@@ -12,6 +12,7 @@ export interface SecurityQuote {
   financialData: FinancialData;
   summaryDetail: SummaryDetail;
   cashflowStatementHistory?: CashflowStatementHistory;
+  assetProfile?: AssetProfile;
 }
 
 export interface HistoricalDataPoint {
@@ -63,7 +64,8 @@ class FinancialService {
         'price',
         'financialData',
         'summaryDetail',
-        'cashflowStatementHistory'
+        'cashflowStatementHistory',
+        'assetProfile'
       ]);
 
       // Validate required fields
@@ -74,13 +76,15 @@ class FinancialService {
       const financialData = quoteSummary.financialData as FinancialData;
       const summaryDetail = quoteSummary.summaryDetail as SummaryDetail;
       const cashflowStatementHistory = quoteSummary.cashflowStatementHistory;
+      const assetProfile = quoteSummary.assetProfile;
 
       return {
         symbol,
         price,
         financialData,
         summaryDetail,
-        cashflowStatementHistory
+        cashflowStatementHistory,
+        assetProfile
       };
     } catch (error) {
       if (error instanceof DataValidationError) {

--- a/src/services/portfolioDataService.ts
+++ b/src/services/portfolioDataService.ts
@@ -1,7 +1,6 @@
 import { supabase } from '@/lib/supabase';
 import { handleYahooFinanceError } from '@/src/lib/financial/api/errors';
 import { Portfolio, PortfolioSecurity, Security } from './portfolioService';
-import { financialService } from './financialService';
 import { QuoteSummary } from '@/lib/financial/api/yahoo/types';
 
 interface DatabaseSecurity {
@@ -10,6 +9,27 @@ interface DatabaseSecurity {
   name: string;
   sector: string;
   industry: string;
+  address1?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  country?: string;
+  phone?: string;
+  website?: string;
+  industry_key?: string;
+  industry_disp?: string;
+  sector_key?: string;
+  sector_disp?: string;
+  long_business_summary?: string;
+  full_time_employees?: number;
+  audit_risk?: number;
+  board_risk?: number;
+  compensation_risk?: number;
+  shareholder_rights_risk?: number;
+  overall_risk?: number;
+  governance_epoch_date?: string;
+  compensation_as_of_epoch_date?: string;
+  ir_website?: string;
   price: number;
   prev_close: number;
   open: number;
@@ -42,12 +62,126 @@ interface PortfolioSecurityRecord {
   security_id: string;
   shares: number;
   average_cost: number;
-  security: DatabaseSecurity;
+  security: Security;
+}
+
+interface BatchResponse {
+  ticker: string;
+  data: QuoteSummary;
+}
+
+interface SupabasePortfolioSecurity {
+  id: string;
+  security_id: string;
+  shares: number;
+  average_cost: number;
+  security: {
+    id: string;
+    ticker: string;
+    name: string;
+    sector: string;
+    industry: string;
+    price: number;
+    prev_close: number;
+    open: number;
+    volume: number;
+    market_cap: number;
+    pe: number;
+    eps: number;
+    dividend: number;
+    yield: number;
+    dividend_growth_5yr: number;
+    payout_ratio: number;
+    sma200: string;
+    tags: string[];
+    day_low: number;
+    day_high: number;
+    fifty_two_week_low: number;
+    fifty_two_week_high: number;
+    average_volume: number;
+    forward_pe: number;
+    price_to_sales_trailing_12_months: number;
+    beta: number;
+    fifty_day_average: number;
+    two_hundred_day_average: number;
+    ex_dividend_date: string;
+    last_fetched: string;
+  };
 }
 
 export const portfolioDataService = {
   async updatePortfolioSecurities(portfolioId: string): Promise<PortfolioSecurity[]> {
     try {
+      // Helper function to format dates
+      const formatDate = (timestamp: number | undefined, fieldName?: string) => {
+        if (!timestamp) return null;
+        try {
+          // Special handling for epoch dates from Yahoo Finance
+          if (fieldName === 'governance_epoch_date' || fieldName === 'compensation_as_of_epoch_date') {
+            // These dates might be in a different format, try parsing as a regular date first
+            const date = new Date(timestamp);
+            if (!isNaN(date.getTime())) {
+              const year = date.getFullYear();
+              if (year >= 1900 && year <= 2100) {
+                return date.toISOString();
+              }
+            }
+            // If that fails, try the original epoch conversion
+            const epochDate = new Date(timestamp * 1000);
+            if (!isNaN(epochDate.getTime())) {
+              const year = epochDate.getFullYear();
+              if (year >= 1900 && year <= 2100) {
+                return epochDate.toISOString();
+              }
+            }
+            console.warn(`Invalid date format for ${fieldName}:`, timestamp);
+            return null;
+          }
+
+          // Special handling for ex-dividend date
+          if (fieldName === 'ex_dividend_date') {
+            // Try parsing as a regular date first
+            const date = new Date(timestamp);
+            if (!isNaN(date.getTime())) {
+              const year = date.getFullYear();
+              if (year >= 1900 && year <= 2100) {
+                return date.toISOString();
+              }
+            }
+            // If that fails, try the epoch conversion
+            const epochDate = new Date(timestamp * 1000);
+            if (!isNaN(epochDate.getTime())) {
+              const year = epochDate.getFullYear();
+              if (year >= 1900 && year <= 2100) {
+                return epochDate.toISOString();
+              }
+            }
+            console.warn(`Invalid ex-dividend date format:`, timestamp);
+            return null;
+          }
+
+          // Default handling for other dates
+          if (isNaN(timestamp)) {
+            console.warn(`Invalid timestamp for ${fieldName || 'unknown field'}:`, timestamp);
+            return null;
+          }
+          const date = new Date(timestamp * 1000);
+          if (isNaN(date.getTime())) {
+            console.warn(`Invalid date from timestamp for ${fieldName || 'unknown field'}:`, timestamp);
+            return null;
+          }
+          const year = date.getFullYear();
+          if (year < 1900 || year > 2100) {
+            console.warn(`Date year out of reasonable range for ${fieldName || 'unknown field'}:`, year);
+            return null;
+          }
+          return date.toISOString();
+        } catch (error) {
+          console.error(`Error formatting date for ${fieldName || 'unknown field'}:`, error);
+          return null;
+        }
+      };
+
       // Fetch portfolio securities from the database
       const { data: portfolioSecurities, error: fetchError } = await supabase
         .from('portfolio_securities')
@@ -91,108 +225,179 @@ export const portfolioDataService = {
         `)
         .eq('portfolio_id', portfolioId);
 
-      if (fetchError) throw fetchError;
-      if (!portfolioSecurities) return [];
+      if (fetchError) {
+        console.error('Error fetching portfolio securities:', fetchError);
+        throw new Error(`Failed to fetch portfolio securities: ${fetchError.message}`);
+      }
+      if (!portfolioSecurities) {
+        console.warn('No portfolio securities found for portfolio:', portfolioId);
+        return [];
+      }
+
+      // Get all unique tickers
+      const tickers = Array.from(new Set((portfolioSecurities as unknown as SupabasePortfolioSecurity[]).map(ps => ps.security.ticker)));
+      if (tickers.length === 0) {
+        console.warn('No tickers found in portfolio securities');
+        return [];
+      }
+
+      // Get the current session
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        console.error('No active session found');
+        throw new Error('Authentication required: No active session');
+      }
+
+      // Fetch data for all securities in one batch
+      const response = await fetch('/api/securities/batch', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`
+        },
+        body: JSON.stringify({ tickers })
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        console.error('API error response:', error);
+        throw new Error(`Failed to fetch securities data: ${error.error || response.statusText}`);
+      }
+
+      const results = await response.json() as BatchResponse[];
+      if (!results || results.length === 0) {
+        console.warn('No results returned from securities batch API');
+        return [];
+      }
+
+      // Create a map of ticker to quote summary for easy lookup
+      const quoteSummaryMap = new Map(
+        results.map(result => [result.ticker, result.data])
+      );
 
       // Update each security with fresh data
       const updatedSecurities = await Promise.all(
         (portfolioSecurities as unknown as PortfolioSecurityRecord[]).map(async (ps) => {
-          try {
-            const quoteSummary = await financialService.getQuoteSummary(ps.security.ticker);
-            if (!quoteSummary) return ps;
+          const quoteSummary = quoteSummaryMap.get(ps.security.ticker);
+          if (!quoteSummary) return ps;
 
-            const {
-              price,
-              summaryDetail,
-              price: priceData
-            } = quoteSummary;
+          const {
+            price,
+            summaryDetail,
+            price: priceData,
+            assetProfile,
+            financialData,
+            cashflowStatementHistory
+          } = quoteSummary;
 
-            // Update the security in the database
-            const { data: updatedSecurity, error: updateError } = await supabase
-              .from('securities')
-              .update({
-                name: priceData?.longName || priceData?.shortName || ps.security.ticker,
-                sector: quoteSummary.assetProfile?.sector || 'Unknown',
-                industry: quoteSummary.assetProfile?.industry || 'Unknown',
-                price: price?.regularMarketPrice || 0,
-                prev_close: price?.regularMarketPreviousClose || 0,
-                open: price?.regularMarketOpen || 0,
-                volume: price?.regularMarketVolume || 0,
-                market_cap: price?.marketCap || 0,
-                pe: summaryDetail?.trailingPE || 0,
-                eps: summaryDetail?.trailingPE || 0, // Using trailingPE as fallback since trailingEps is not available
-                dividend: summaryDetail?.dividendRate || 0,
-                yield: summaryDetail?.dividendYield ? summaryDetail.dividendYield * 100 : null,
-                dividend_growth_5yr: summaryDetail?.fiveYearAvgDividendYield || 0,
-                payout_ratio: summaryDetail?.payoutRatio || 0,
-                sma200: (price?.regularMarketPrice || 0) > (summaryDetail?.twoHundredDayAverage || 0) ? 'above' : 'below',
-                day_low: price?.regularMarketDayLow || 0,
-                day_high: price?.regularMarketDayHigh || 0,
-                fifty_two_week_low: price?.regularMarketDayLow || 0,
-                fifty_two_week_high: price?.regularMarketDayHigh || 0,
-                average_volume: summaryDetail?.averageVolume || 0,
-                forward_pe: summaryDetail?.forwardPE || 0,
-                price_to_sales_trailing_12_months: summaryDetail?.priceToSalesTrailing12Months || 0,
-                beta: summaryDetail?.beta || 0,
-                fifty_day_average: summaryDetail?.fiftyDayAverage || 0,
-                two_hundred_day_average: summaryDetail?.twoHundredDayAverage || 0,
-                ex_dividend_date: summaryDetail?.exDividendDate ? new Date(summaryDetail.exDividendDate * 1000).toISOString() : null,
-                // Add financial data fields
-                target_low_price: quoteSummary.financialData?.targetLowPrice || 0,
-                target_high_price: quoteSummary.financialData?.targetHighPrice || 0,
-                recommendation_key: quoteSummary.financialData?.recommendationKey || null,
-                number_of_analyst_opinions: quoteSummary.financialData?.numberOfAnalystOpinions || 0,
-                total_cash: quoteSummary.financialData?.totalCash || 0,
-                total_debt: quoteSummary.financialData?.totalDebt || 0,
-                current_ratio: quoteSummary.financialData?.currentRatio || 0,
-                quick_ratio: quoteSummary.financialData?.quickRatio || 0,
-                debt_to_equity: quoteSummary.financialData?.debtToEquity,
-                return_on_equity: quoteSummary.financialData?.returnOnEquity,
-                profit_margins: quoteSummary.financialData?.profitMargins,
-                operating_margins: quoteSummary.financialData?.operatingMargins,
-                revenue_growth: quoteSummary.financialData?.revenueGrowth,
-                earnings_growth: quoteSummary.financialData?.earningsGrowth,
-                // Add cash flow data
-                operating_cash_flow: quoteSummary.financialData?.operatingCashflow,
-                free_cash_flow: quoteSummary.financialData?.freeCashflow,
-                cash_flow_growth: quoteSummary.cashflowStatementHistory?.cashflowStatements[0]?.totalCashFromOperatingActivities,
-                last_fetched: new Date().toISOString()
-              })
-              .eq('ticker', ps.security.ticker)
-              .select()
-              .single();
+          // Update the security in the database
+          const { data: updatedSecurity, error: updateError } = await supabase
+            .from('securities')
+            .update({
+              name: priceData?.longName || priceData?.shortName || ps.security.ticker,
+              sector: assetProfile?.sector || 'Unknown',
+              industry: assetProfile?.industry || 'Unknown',
+              address1: assetProfile?.address1,
+              city: assetProfile?.city,
+              state: assetProfile?.state,
+              zip: assetProfile?.zip,
+              country: assetProfile?.country,
+              phone: assetProfile?.phone,
+              website: assetProfile?.website,
+              industry_key: assetProfile?.industryKey,
+              industry_disp: assetProfile?.industryDisp,
+              sector_key: assetProfile?.sectorKey,
+              sector_disp: assetProfile?.sectorDisp,
+              long_business_summary: assetProfile?.longBusinessSummary,
+              full_time_employees: assetProfile?.fullTimeEmployees,
+              audit_risk: assetProfile?.auditRisk,
+              board_risk: assetProfile?.boardRisk,
+              compensation_risk: assetProfile?.compensationRisk,
+              shareholder_rights_risk: assetProfile?.shareHolderRightsRisk,
+              overall_risk: assetProfile?.overallRisk,
+              governance_epoch_date: assetProfile?.governanceEpochDate ? formatDate(assetProfile.governanceEpochDate, 'governance_epoch_date') : null,
+              compensation_as_of_epoch_date: assetProfile?.compensationAsOfEpochDate ? formatDate(assetProfile.compensationAsOfEpochDate, 'compensation_as_of_epoch_date') : null,
+              ir_website: assetProfile?.irWebsite,
+              price: price?.regularMarketPrice || 0,
+              prev_close: price?.regularMarketPreviousClose || 0,
+              open: price?.regularMarketOpen || 0,
+              volume: price?.regularMarketVolume || 0,
+              market_cap: price?.marketCap || 0,
+              pe: summaryDetail?.trailingPE || 0,
+              eps: summaryDetail?.trailingPE || 0,
+              dividend: summaryDetail?.dividendRate || 0,
+              yield: summaryDetail?.dividendYield ? summaryDetail.dividendYield * 100 : null,
+              dividend_growth_5yr: summaryDetail?.fiveYearAvgDividendYield || 0,
+              payout_ratio: summaryDetail?.payoutRatio || 0,
+              sma200: (price?.regularMarketPrice || 0) > (summaryDetail?.twoHundredDayAverage || 0) ? 'above' : 'below',
+              day_low: price?.regularMarketDayLow || 0,
+              day_high: price?.regularMarketDayHigh || 0,
+              fifty_two_week_low: price?.regularMarketDayLow || 0,
+              fifty_two_week_high: price?.regularMarketDayHigh || 0,
+              average_volume: summaryDetail?.averageVolume || 0,
+              forward_pe: summaryDetail?.forwardPE || 0,
+              price_to_sales_trailing_12_months: summaryDetail?.priceToSalesTrailing12Months || 0,
+              beta: summaryDetail?.beta || 0,
+              fifty_day_average: summaryDetail?.fiftyDayAverage || 0,
+              two_hundred_day_average: summaryDetail?.twoHundredDayAverage || 0,
+              ex_dividend_date: summaryDetail?.exDividendDate ? formatDate(summaryDetail.exDividendDate, 'ex_dividend_date') : null,
+              // Add financial data fields
+              target_low_price: financialData?.targetLowPrice || 0,
+              target_high_price: financialData?.targetHighPrice || 0,
+              recommendation_key: financialData?.recommendationKey || null,
+              number_of_analyst_opinions: financialData?.numberOfAnalystOpinions || 0,
+              total_cash: financialData?.totalCash || 0,
+              total_debt: financialData?.totalDebt || 0,
+              current_ratio: financialData?.currentRatio || 0,
+              quick_ratio: financialData?.quickRatio || 0,
+              debt_to_equity: financialData?.debtToEquity,
+              return_on_equity: financialData?.returnOnEquity,
+              profit_margins: financialData?.profitMargins,
+              operating_margins: financialData?.operatingMargins,
+              revenue_growth: financialData?.revenueGrowth,
+              earnings_growth: financialData?.earningsGrowth,
+              // Add cash flow data
+              operating_cash_flow: financialData?.operatingCashflow,
+              free_cash_flow: financialData?.freeCashflow,
+              cash_flow_growth: cashflowStatementHistory?.cashflowStatements[0]?.totalCashFromOperatingActivities,
+              last_fetched: new Date().toISOString()
+            })
+            .eq('id', ps.security.id)
+            .select()
+            .single();
 
-            if (updateError) throw updateError;
-
-            return {
-              id: ps.id,
-              shares: ps.shares,
-              average_cost: ps.average_cost,
-              security: {
-                ...updatedSecurity,
-                id: ps.security.id,
-                ex_dividend_date: updatedSecurity.ex_dividend_date || ''
-              } as Security
-            } as PortfolioSecurity;
-          } catch (error) {
-            console.error(`Error updating security ${ps.security.ticker}:`, error);
-            return {
-              id: ps.id,
-              shares: ps.shares,
-              average_cost: ps.average_cost,
-              security: {
-                ...ps.security,
-                ex_dividend_date: ps.security.ex_dividend_date || ''
-              } as Security
-            } as PortfolioSecurity;
+          if (updateError) {
+            console.error('Error updating security:', {
+              securityId: ps.security.id,
+              ticker: ps.security.ticker,
+              error: updateError
+            });
+            throw new Error(`Failed to update security ${ps.security.ticker}: ${updateError.message}`);
           }
+
+          if (!updatedSecurity) {
+            console.warn('No security data returned after update:', {
+              securityId: ps.security.id,
+              ticker: ps.security.ticker
+            });
+            return ps; // Return original security if update didn't return data
+          }
+
+          return {
+            ...ps,
+            security: updatedSecurity
+          };
         })
       );
 
       return updatedSecurities;
     } catch (error) {
-      console.error('Error updating portfolio securities:', error);
-      handleYahooFinanceError(error);
+      console.error('Error updating portfolio securities:', {
+        error,
+        message: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+        details: error
+      });
       throw error;
     }
   }

--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -6,6 +6,27 @@ export interface Security {
   name: string;
   sector: string;
   industry: string;
+  address1?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  country?: string;
+  phone?: string;
+  website?: string;
+  industry_key?: string;
+  industry_disp?: string;
+  sector_key?: string;
+  sector_disp?: string;
+  long_business_summary?: string;
+  full_time_employees?: number;
+  audit_risk?: number;
+  board_risk?: number;
+  compensation_risk?: number;
+  shareholder_rights_risk?: number;
+  overall_risk?: number;
+  governance_epoch_date?: string;
+  compensation_as_of_epoch_date?: string;
+  ir_website?: string;
   price: number;
   prev_close: number;
   open: number;
@@ -30,6 +51,9 @@ export interface Security {
   fifty_day_average: number;
   two_hundred_day_average: number;
   ex_dividend_date: string;
+  operating_cash_flow: number;
+  free_cash_flow: number;
+  cash_flow_growth: number;
   last_fetched: string;
 }
 

--- a/src/services/securityDataService.ts
+++ b/src/services/securityDataService.ts
@@ -1,214 +1,190 @@
 import { supabase } from '@/lib/supabase';
-import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
-import { handleYahooFinanceError } from '@/lib/financial/api/errors';
-import { dividendService } from './dividendService';
+import { Security } from './portfolioService';
+import { QuoteSummary } from '@/lib/financial/api/yahoo/types';
 
-export interface Security {
-  id: string;
-  ticker: string;
-  name: string;
-  sector: string;
-  industry: string;
-  price: number;
-  prev_close: number;
-  open: number;
-  volume: number;
-  market_cap: number;
-  pe: number;
-  eps: number;
-  dividend: number;
-  yield: number;
-  dividend_growth_5yr: number;
-  payout_ratio: number;
-  sma200: 'above' | 'below';
-  tags: string[];
-  day_low: number;
-  day_high: number;
-  fifty_two_week_low: number;
-  fifty_two_week_high: number;
-  average_volume: number;
-  forward_pe: number;
-  price_to_sales_trailing_12_months: number;
-  beta: number;
-  fifty_day_average: number;
-  two_hundred_day_average: number;
-  ex_dividend_date: string;
-  target_low_price: number;
-  target_high_price: number;
-  recommendation_key: string;
-  number_of_analyst_opinions: number;
-  total_cash: number;
-  total_debt: number;
-  current_ratio: number;
-  quick_ratio: number;
-  debt_to_equity: number;
-  return_on_equity: number;
-  profit_margins: number;
-  operating_margins: number;
-  revenue_growth: number;
-  earnings_growth: number;
-  last_fetched: string;
-}
+export type { Security };
 
 export const securityService = {
-  async getSecurityData(ticker: string): Promise<Partial<Security> | null> {
+  async getSecurityData(ticker: string): Promise<Security | null> {
     try {
-      console.log('Getting security data for ticker:', ticker);
-      // Get quote summary from Yahoo Finance
-      const quoteSummary = await yahooFinanceClient.getQuoteSummary(ticker);
-      
-      if (!quoteSummary) {
-        console.error('No data returned from Yahoo Finance for ticker:', ticker);
-        return null;
+      // Get the current session
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) throw new Error('No active session');
+
+      // Fetch data from our API endpoint
+      const response = await fetch(`/api/securities/${ticker}`, {
+        headers: {
+          'Authorization': `Bearer ${session.access_token}`
+        }
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to fetch security data');
       }
 
-      console.log('Got quote summary for', ticker, quoteSummary);
+      const quoteSummary = await response.json() as QuoteSummary;
+      if (!quoteSummary) return null;
 
       // Extract relevant data from quote summary
       const price = quoteSummary.price?.regularMarketPrice || 0;
-      const dividendYield = quoteSummary.summaryDetail?.dividendYield || 0;
-      const sma200 = price > (quoteSummary.summaryDetail?.twoHundredDayAverage || 0) ? 'above' as const : 'below' as const;
-      
-      // Get dividend data
-      const exDate = quoteSummary.summaryDetail?.exDividendDate;
-      const paymentDate = exDate ? new Date(exDate * 1000) : null; // Convert Unix timestamp to Date
-      const estimatedPaymentDate = paymentDate ? new Date(paymentDate.getTime() + 30 * 24 * 60 * 60 * 1000) : null; // Estimate payment date as 30 days after ex-date
-      
-      const securityData: Partial<Security> = {
-        name: quoteSummary.price?.longName || quoteSummary.price?.shortName || ticker,
-        sector: quoteSummary.assetProfile?.sector || 'Unknown',
-        price,
-        yield: dividendYield * 100, // Convert to percentage
-        sma200,
-        tags: [quoteSummary.assetProfile?.sector || 'Unknown'],
-        dividend_growth_5yr: quoteSummary.summaryDetail?.fiveYearAvgDividendYield ? quoteSummary.summaryDetail.fiveYearAvgDividendYield * 100 : 0 // Convert to percentage
+      const prev_close = quoteSummary.price?.regularMarketPreviousClose || 0;
+      const open = quoteSummary.price?.regularMarketOpen || 0;
+      const volume = quoteSummary.price?.regularMarketVolume || 0;
+      const market_cap = quoteSummary.price?.marketCap || 0;
+      const pe = quoteSummary.summaryDetail?.trailingPE || 0;
+      const eps = quoteSummary.summaryDetail?.trailingPE || 0;
+      const dividend = quoteSummary.summaryDetail?.dividendRate || 0;
+      const dividendYield = (quoteSummary.summaryDetail?.dividendYield || 0) * 100;
+      const dividend_growth_5yr = quoteSummary.summaryDetail?.fiveYearAvgDividendYield || 0;
+      const payout_ratio = quoteSummary.summaryDetail?.payoutRatio || 0;
+      const sma200 = price > (quoteSummary.summaryDetail?.twoHundredDayAverage || 0) ? 'above' : 'below';
+      const day_low = quoteSummary.price?.regularMarketDayLow || 0;
+      const day_high = quoteSummary.price?.regularMarketDayHigh || 0;
+      const fifty_two_week_low = quoteSummary.summaryDetail?.fiftyTwoWeekLow || 0;
+      const fifty_two_week_high = quoteSummary.summaryDetail?.fiftyTwoWeekHigh || 0;
+      const average_volume = quoteSummary.summaryDetail?.averageVolume || 0;
+      const forward_pe = quoteSummary.summaryDetail?.forwardPE || 0;
+      const price_to_sales_trailing_12_months = quoteSummary.summaryDetail?.priceToSalesTrailing12Months || 0;
+      const beta = quoteSummary.summaryDetail?.beta || 0;
+      const fifty_day_average = quoteSummary.summaryDetail?.fiftyDayAverage || 0;
+      const two_hundred_day_average = quoteSummary.summaryDetail?.twoHundredDayAverage || 0;
+
+      // Format date to ISO string with timezone for PostgreSQL TIMESTAMP WITH TIME ZONE
+      const formatDate = (timestamp: number | undefined) => {
+        if (!timestamp) return null;
+        try {
+          if (isNaN(timestamp)) {
+            console.warn('Invalid timestamp:', timestamp);
+            return null;
+          }
+
+          const date = new Date(timestamp * 1000);
+          
+          if (isNaN(date.getTime())) {
+            console.warn('Invalid date from timestamp:', timestamp);
+            return null;
+          }
+
+          const year = date.getUTCFullYear();
+          const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+          const day = String(date.getUTCDate()).padStart(2, '0');
+          
+          return `${year}-${month}-${day}`;
+        } catch (error) {
+          console.error('Error formatting date:', error);
+          return null;
+        }
       };
 
-      // If we have dividend data, store it
-      if (exDate && paymentDate && estimatedPaymentDate) {
-        try {
-          // Get the security ID from the database
-          const { data: security } = await supabase
-            .from('securities')
-            .select('id')
-            .eq('ticker', ticker)
-            .single();
+      const ex_dividend_date = formatDate(quoteSummary.summaryDetail?.exDividendDate);
 
-          if (security) {
-            await dividendService.updateDividendDates(
-              security.id,
-              paymentDate.toISOString(),
-              estimatedPaymentDate.toISOString()
-            );
-            console.log('Updated dividend dates for', ticker);
-          }
-        } catch (error) {
-          console.error('Error updating dividend dates:', error);
-        }
-      }
-
-      return securityData;
+      return {
+        id: '', // Will be set by database
+        ticker,
+        name: quoteSummary.price?.longName || quoteSummary.price?.shortName || ticker,
+        sector: quoteSummary.assetProfile?.sector || 'Unknown',
+        industry: quoteSummary.assetProfile?.industry || 'Unknown',
+        price,
+        prev_close,
+        open,
+        volume,
+        market_cap,
+        pe,
+        eps,
+        dividend,
+        yield: dividendYield,
+        dividend_growth_5yr,
+        payout_ratio,
+        sma200,
+        tags: [],
+        day_low,
+        day_high,
+        fifty_two_week_low,
+        fifty_two_week_high,
+        average_volume,
+        forward_pe,
+        price_to_sales_trailing_12_months,
+        beta,
+        fifty_day_average,
+        two_hundred_day_average,
+        ex_dividend_date: ex_dividend_date || '',
+        operating_cash_flow: quoteSummary.financialData?.operatingCashflow || 0,
+        free_cash_flow: quoteSummary.financialData?.freeCashflow || 0,
+        cash_flow_growth: quoteSummary.cashflowStatementHistory?.cashflowStatements[0]?.totalCashFromOperatingActivities || 0,
+        last_fetched: new Date().toISOString()
+      };
     } catch (error) {
       console.error('Error fetching security data:', error);
-      handleYahooFinanceError(error);
       return null;
     }
   },
 
   async updateSecurityData(securityId: string): Promise<Security | null> {
     try {
-      console.log('Starting security update for ID:', securityId);
-      
-      // Get the security from the database
-      const { data: security, error: fetchError } = await supabase
+      // Get the security from the database to get its ticker
+      const { data: security, error: securityError } = await supabase
         .from('securities')
         .select('*')
         .eq('id', securityId)
         .single();
 
-      if (fetchError || !security) {
-        console.error('Error fetching security:', fetchError);
+      if (securityError) {
+        console.error('Error fetching security:', securityError);
         return null;
       }
 
-      console.log('Fetched existing security:', security);
-
-      // Get updated data
+      // Get updated data using our API endpoint
       const updatedData = await this.getSecurityData(security.ticker);
-      if (!updatedData) {
-        console.error('No updated data returned for ticker:', security.ticker);
-        return security;
-      }
-
-      console.log('Got updated data from Yahoo Finance:', updatedData);
+      if (!updatedData) return null;
 
       // Update the security in the database
       const { data: updatedSecurity, error: updateError } = await supabase
         .from('securities')
         .update({
-          name: updatedData.name || security.name,
-          sector: updatedData.sector || security.sector,
-          industry: updatedData.industry || security.industry,
-          price: updatedData.price || security.price,
-          prev_close: updatedData.prev_close || security.prev_close,
-          open: updatedData.open || security.open,
-          volume: updatedData.volume || security.volume,
-          market_cap: updatedData.market_cap || security.market_cap,
-          pe: updatedData.pe || security.pe,
-          eps: updatedData.eps || security.eps,
-          dividend: updatedData.dividend || security.dividend,
-          yield: updatedData.yield || security.yield,
-          dividend_growth_5yr: updatedData.dividend_growth_5yr || security.dividend_growth_5yr,
-          payout_ratio: updatedData.payout_ratio || security.payout_ratio,
-          sma200: updatedData.sma200 || security.sma200,
-          tags: updatedData.tags || security.tags,
-          day_low: updatedData.day_low || security.day_low,
-          day_high: updatedData.day_high || security.day_high,
-          fifty_two_week_low: updatedData.fifty_two_week_low || security.fifty_two_week_low,
-          fifty_two_week_high: updatedData.fifty_two_week_high || security.fifty_two_week_high,
-          average_volume: updatedData.average_volume || security.average_volume,
-          forward_pe: updatedData.forward_pe || security.forward_pe,
-          price_to_sales_trailing_12_months: updatedData.price_to_sales_trailing_12_months || security.price_to_sales_trailing_12_months,
-          beta: updatedData.beta || security.beta,
-          fifty_day_average: updatedData.fifty_day_average || security.fifty_day_average,
-          two_hundred_day_average: updatedData.two_hundred_day_average || security.two_hundred_day_average,
-          ex_dividend_date: updatedData.ex_dividend_date || security.ex_dividend_date,
-          target_low_price: updatedData.target_low_price || security.target_low_price,
-          target_high_price: updatedData.target_high_price || security.target_high_price,
-          recommendation_key: updatedData.recommendation_key || security.recommendation_key,
-          number_of_analyst_opinions: updatedData.number_of_analyst_opinions || security.number_of_analyst_opinions,
-          total_cash: updatedData.total_cash || security.total_cash,
-          total_debt: updatedData.total_debt || security.total_debt,
-          current_ratio: updatedData.current_ratio || security.current_ratio,
-          quick_ratio: updatedData.quick_ratio || security.quick_ratio,
-          debt_to_equity: updatedData.debt_to_equity || security.debt_to_equity,
-          return_on_equity: updatedData.return_on_equity || security.return_on_equity,
-          profit_margins: updatedData.profit_margins || security.profit_margins,
-          operating_margins: updatedData.operating_margins || security.operating_margins,
-          revenue_growth: updatedData.revenue_growth || security.revenue_growth,
-          earnings_growth: updatedData.earnings_growth || security.earnings_growth,
-          updated_at: new Date().toISOString(),
+          name: updatedData.name,
+          sector: updatedData.sector,
+          industry: updatedData.industry,
+          price: updatedData.price,
+          prev_close: updatedData.prev_close,
+          open: updatedData.open,
+          volume: updatedData.volume,
+          market_cap: updatedData.market_cap,
+          pe: updatedData.pe,
+          eps: updatedData.eps,
+          dividend: updatedData.dividend,
+          yield: updatedData.yield,
+          dividend_growth_5yr: updatedData.dividend_growth_5yr,
+          payout_ratio: updatedData.payout_ratio,
+          sma200: updatedData.sma200,
+          day_low: updatedData.day_low,
+          day_high: updatedData.day_high,
+          fifty_two_week_low: updatedData.fifty_two_week_low,
+          fifty_two_week_high: updatedData.fifty_two_week_high,
+          average_volume: updatedData.average_volume,
+          forward_pe: updatedData.forward_pe,
+          price_to_sales_trailing_12_months: updatedData.price_to_sales_trailing_12_months,
+          beta: updatedData.beta,
+          fifty_day_average: updatedData.fifty_day_average,
+          two_hundred_day_average: updatedData.two_hundred_day_average,
+          ex_dividend_date: updatedData.ex_dividend_date,
+          operating_cash_flow: updatedData.operating_cash_flow,
+          free_cash_flow: updatedData.free_cash_flow,
+          cash_flow_growth: updatedData.cash_flow_growth,
           last_fetched: new Date().toISOString()
         })
         .eq('id', securityId)
         .select()
-        .maybeSingle();
+        .single();
 
       if (updateError) {
         console.error('Error updating security:', updateError);
-        console.error('Update error details:', {
-          code: updateError.code,
-          message: updateError.message,
-          details: updateError.details,
-          hint: updateError.hint
-        });
-        return security;
+        return null;
       }
 
-      console.log('Successfully updated security:', updatedSecurity);
       return updatedSecurity;
     } catch (error) {
-      console.error('Error in updateSecurityData:', error);
+      console.error('Error updating security data:', error);
       return null;
     }
   },

--- a/supabase/migrations/20240321000007_add_asset_profile.sql
+++ b/supabase/migrations/20240321000007_add_asset_profile.sql
@@ -1,0 +1,69 @@
+-- Add asset profile fields to securities table
+ALTER TABLE public.securities
+ADD COLUMN IF NOT EXISTS address1 TEXT,
+ADD COLUMN IF NOT EXISTS city TEXT,
+ADD COLUMN IF NOT EXISTS state TEXT,
+ADD COLUMN IF NOT EXISTS zip TEXT,
+ADD COLUMN IF NOT EXISTS country TEXT,
+ADD COLUMN IF NOT EXISTS phone TEXT,
+ADD COLUMN IF NOT EXISTS website TEXT,
+ADD COLUMN IF NOT EXISTS industry_key TEXT,
+ADD COLUMN IF NOT EXISTS industry_disp TEXT,
+ADD COLUMN IF NOT EXISTS sector_key TEXT,
+ADD COLUMN IF NOT EXISTS sector_disp TEXT,
+ADD COLUMN IF NOT EXISTS long_business_summary TEXT,
+ADD COLUMN IF NOT EXISTS full_time_employees INTEGER,
+ADD COLUMN IF NOT EXISTS audit_risk INTEGER,
+ADD COLUMN IF NOT EXISTS board_risk INTEGER,
+ADD COLUMN IF NOT EXISTS compensation_risk INTEGER,
+ADD COLUMN IF NOT EXISTS shareholder_rights_risk INTEGER,
+ADD COLUMN IF NOT EXISTS overall_risk INTEGER,
+ADD COLUMN IF NOT EXISTS governance_epoch_date TIMESTAMP WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS compensation_as_of_epoch_date TIMESTAMP WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS ir_website TEXT;
+
+-- Update the last_fetched trigger to include asset profile fields
+CREATE OR REPLACE FUNCTION update_last_fetched()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only update last_fetched if price-related or asset profile fields are being updated
+    IF (
+        OLD.price IS DISTINCT FROM NEW.price OR
+        OLD.yield IS DISTINCT FROM NEW.yield OR
+        OLD.sma200 IS DISTINCT FROM NEW.sma200 OR
+        OLD.address1 IS DISTINCT FROM NEW.address1 OR
+        OLD.city IS DISTINCT FROM NEW.city OR
+        OLD.state IS DISTINCT FROM NEW.state OR
+        OLD.zip IS DISTINCT FROM NEW.zip OR
+        OLD.country IS DISTINCT FROM NEW.country OR
+        OLD.phone IS DISTINCT FROM NEW.phone OR
+        OLD.website IS DISTINCT FROM NEW.website OR
+        OLD.industry_key IS DISTINCT FROM NEW.industry_key OR
+        OLD.industry_disp IS DISTINCT FROM NEW.industry_disp OR
+        OLD.sector_key IS DISTINCT FROM NEW.sector_key OR
+        OLD.sector_disp IS DISTINCT FROM NEW.sector_disp OR
+        OLD.long_business_summary IS DISTINCT FROM NEW.long_business_summary OR
+        OLD.full_time_employees IS DISTINCT FROM NEW.full_time_employees OR
+        OLD.audit_risk IS DISTINCT FROM NEW.audit_risk OR
+        OLD.board_risk IS DISTINCT FROM NEW.board_risk OR
+        OLD.compensation_risk IS DISTINCT FROM NEW.compensation_risk OR
+        OLD.shareholder_rights_risk IS DISTINCT FROM NEW.shareholder_rights_risk OR
+        OLD.overall_risk IS DISTINCT FROM NEW.overall_risk OR
+        OLD.governance_epoch_date IS DISTINCT FROM NEW.governance_epoch_date OR
+        OLD.compensation_as_of_epoch_date IS DISTINCT FROM NEW.compensation_as_of_epoch_date OR
+        OLD.ir_website IS DISTINCT FROM NEW.ir_website
+    ) THEN
+        NEW.last_fetched = timezone('utc'::text, now());
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop existing trigger if it exists
+DROP TRIGGER IF EXISTS update_security_last_fetched ON public.securities;
+
+-- Create trigger
+CREATE TRIGGER update_security_last_fetched
+    BEFORE UPDATE ON public.securities
+    FOR EACH ROW
+    EXECUTE FUNCTION update_last_fetched(); 


### PR DESCRIPTION
This commit adds comprehensive asset profile data to securities, including company details, governance metrics, and risk assessments. Major changes include:

- Add new asset profile fields to securities table (address, contact info, business summary, etc.)
- Add governance and risk metrics (audit risk, board risk, compensation risk, etc.)
- Update security data services to handle new asset profile fields
- Add batch processing for security data updates
- Improve date formatting and validation for various date fields
- Update database triggers to track changes in asset profile fields
- Add comprehensive test coverage for portfolio data service