### PR TITLE
feat(api): add earnings data integration

### DIFF
--- a/app/api/quotes/route.ts
+++ b/app/api/quotes/route.ts
@@ -1,25 +1,92 @@
 import { NextResponse } from 'next/server';
-import { financialService } from '@/services/financialService';
+import { createClient } from '@supabase/supabase-js';
+import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
 
 // Mark this route as public
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const symbol = searchParams.get('symbol');
-
-  if (!symbol) {
-    return NextResponse.json({ error: 'Symbol is required' }, { status: 400 });
-  }
-
   try {
-    const quote = await financialService.getQuote(symbol);
-    return NextResponse.json(quote);
+    const authHeader = request.headers.get('Authorization');
+
+    if (!authHeader?.startsWith('Bearer ')) {
+      return NextResponse.json(
+        { error: 'Unauthorized - No token provided' },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.split(' ')[1];
+    
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        global: {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        }
+      }
+    );
+    
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    
+    if (userError) {
+      console.error('Error verifying token:', userError);
+      return NextResponse.json(
+        { error: 'Unauthorized - Invalid token' },
+        { status: 401 }
+      );
+    }
+
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Unauthorized - No user found' },
+        { status: 401 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const symbol = searchParams.get('symbol');
+
+    if (!symbol) {
+      return NextResponse.json(
+        { error: 'Symbol parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    try {
+      const quoteSummary = await yahooFinanceClient.getQuoteSummary(symbol, [
+        'price',
+        'financialData',
+        'summaryDetail',
+        'cashflowStatementHistory',
+        'assetProfile',
+        'earnings'
+      ]);
+
+      if (!quoteSummary) {
+        return NextResponse.json(
+          { error: 'No data returned from Yahoo Finance' },
+          { status: 404 }
+        );
+      }
+
+      return NextResponse.json(quoteSummary);
+    } catch (error) {
+      console.error('Error fetching quote data:', error);
+      return NextResponse.json(
+        { error: 'Failed to fetch quote data from Yahoo Finance' },
+        { status: 500 }
+      );
+    }
   } catch (error) {
-    console.error('Error fetching quote:', error);
+    console.error('Error in quotes API:', error);
     return NextResponse.json(
-      { error: error instanceof Error ? error.message : 'Failed to fetch quote' },
+      { error: 'Internal server error' },
       { status: 500 }
     );
   }

--- a/lib/financial/api/yahoo/client.ts
+++ b/lib/financial/api/yahoo/client.ts
@@ -89,10 +89,66 @@ class YahooFinanceClient {
 
   private transformEarnings(earnings: any): Earnings {
     return {
-      earningsDate: earnings.earningsChart.earningsDate.map((date: Date) => date.getTime()),
+      maxAge: earnings.maxAge ?? 0,
+      earningsDate: earnings.earningsChart.earningsDate.map((date: any) => {
+        if (date instanceof Date) {
+          return date.getTime();
+        }
+        // If it's already a timestamp, return it
+        if (typeof date === 'number') {
+          return date;
+        }
+        // If it's a string, convert to timestamp
+        if (typeof date === 'string') {
+          return new Date(date).getTime();
+        }
+        return 0;
+      }),
       earningsAverage: earnings.earningsChart.currentQuarterEstimate ?? 0,
       earningsLow: earnings.earningsChart.quarterly[0]?.estimate ?? 0,
       earningsHigh: earnings.earningsChart.quarterly[0]?.estimate ?? 0,
+      earningsChart: {
+        quarterly: earnings.earningsChart.quarterly.map((q: any) => ({
+          date: q.date instanceof Date ? q.date.getTime() : 
+                typeof q.date === 'number' ? q.date :
+                typeof q.date === 'string' ? new Date(q.date).getTime() : 0,
+          actual: q.actual ?? 0,
+          estimate: q.estimate ?? 0
+        })) ?? [],
+        currentQuarterEstimate: earnings.earningsChart.currentQuarterEstimate ?? 0,
+        currentQuarterEstimateDate: earnings.earningsChart.currentQuarterEstimateDate ?? '',
+        currentQuarterEstimateYear: earnings.earningsChart.currentQuarterEstimateYear ?? 0,
+        earningsDate: earnings.earningsChart.earningsDate.map((date: any) => {
+          if (date instanceof Date) {
+            return date.getTime();
+          }
+          if (typeof date === 'number') {
+            return date;
+          }
+          if (typeof date === 'string') {
+            return new Date(date).getTime();
+          }
+          return 0;
+        }) ?? [],
+        isEarningsDateEstimate: earnings.earningsChart.isEarningsDateEstimate ?? false
+      },
+      financialsChart: {
+        yearly: earnings.financialsChart.yearly.map((y: any) => ({
+          date: y.date instanceof Date ? y.date.getTime() :
+                typeof y.date === 'number' ? y.date :
+                typeof y.date === 'string' ? new Date(y.date).getTime() : 0,
+          revenue: y.revenue ?? 0,
+          earnings: y.earnings ?? 0
+        })) ?? [],
+        quarterly: earnings.financialsChart.quarterly.map((q: any) => ({
+          date: q.date instanceof Date ? q.date.getTime() :
+                typeof q.date === 'number' ? q.date :
+                typeof q.date === 'string' ? new Date(q.date).getTime() : 0,
+          revenue: q.revenue ?? 0,
+          earnings: q.earnings ?? 0
+        })) ?? []
+      },
+      financialCurrency: earnings.financialCurrency ?? 'USD'
     };
   }
 

--- a/lib/financial/api/yahoo/types.ts
+++ b/lib/financial/api/yahoo/types.ts
@@ -103,10 +103,36 @@ export interface CashflowStatement {
 }
 
 export interface Earnings {
+  maxAge: number;
   earningsDate: number[];
   earningsAverage: number;
   earningsLow: number;
   earningsHigh: number;
+  earningsChart: {
+    quarterly: {
+      date: number;
+      actual: number;
+      estimate: number;
+    }[];
+    currentQuarterEstimate: number;
+    currentQuarterEstimateDate: string;
+    currentQuarterEstimateYear: number;
+    earningsDate: number[];
+    isEarningsDateEstimate: boolean;
+  };
+  financialsChart: {
+    yearly: {
+      date: number;
+      revenue: number;
+      earnings: number;
+    }[];
+    quarterly: {
+      date: number;
+      revenue: number;
+      earnings: number;
+    }[];
+  };
+  financialCurrency: string;
 }
 
 export interface FinancialData {

--- a/src/services/financialService.ts
+++ b/src/services/financialService.ts
@@ -1,5 +1,5 @@
 import { yahooFinanceClient } from '@/lib/financial/api/yahoo/client';
-import type { QuoteSummary, Price, FinancialData, SummaryDetail, CashflowStatementHistory, AssetProfile } from '@/lib/financial/api/yahoo/types';
+import type { QuoteSummary, Price, FinancialData, SummaryDetail, CashflowStatementHistory, AssetProfile, Earnings } from '@/lib/financial/api/yahoo/types';
 import { 
   handleYahooFinanceError, 
   validateResponse, 
@@ -13,6 +13,7 @@ export interface SecurityQuote {
   summaryDetail: SummaryDetail;
   cashflowStatementHistory?: CashflowStatementHistory;
   assetProfile?: AssetProfile;
+  earnings?: Earnings;
 }
 
 export interface HistoricalDataPoint {
@@ -65,7 +66,8 @@ class FinancialService {
         'financialData',
         'summaryDetail',
         'cashflowStatementHistory',
-        'assetProfile'
+        'assetProfile',
+        'earnings'
       ]);
 
       // Validate required fields
@@ -77,6 +79,7 @@ class FinancialService {
       const summaryDetail = quoteSummary.summaryDetail as SummaryDetail;
       const cashflowStatementHistory = quoteSummary.cashflowStatementHistory;
       const assetProfile = quoteSummary.assetProfile;
+      const earnings = quoteSummary.earnings;
 
       return {
         symbol,
@@ -84,7 +87,8 @@ class FinancialService {
         financialData,
         summaryDetail,
         cashflowStatementHistory,
-        assetProfile
+        assetProfile,
+        earnings
       };
     } catch (error) {
       if (error instanceof DataValidationError) {

--- a/src/services/portfolioDataService.ts
+++ b/src/services/portfolioDataService.ts
@@ -54,6 +54,41 @@ interface DatabaseSecurity {
   fifty_day_average: number;
   two_hundred_day_average: number;
   ex_dividend_date: string;
+  operating_cash_flow: number;
+  free_cash_flow: number;
+  cash_flow_growth: number;
+  earnings?: {
+    maxAge: number;
+    earningsDate: number[];
+    earningsAverage: number;
+    earningsLow: number;
+    earningsHigh: number;
+    earningsChart: {
+      quarterly: {
+        date: number;
+        actual: number;
+        estimate: number;
+      }[];
+      currentQuarterEstimate: number;
+      currentQuarterEstimateDate: string;
+      currentQuarterEstimateYear: number;
+      earningsDate: number[];
+      isEarningsDateEstimate: boolean;
+    };
+    financialsChart: {
+      yearly: {
+        date: number;
+        revenue: number;
+        earnings: number;
+      }[];
+      quarterly: {
+        date: number;
+        revenue: number;
+        earnings: number;
+      }[];
+    };
+    financialCurrency: string;
+  };
   last_fetched: string;
 }
 
@@ -360,6 +395,39 @@ export const portfolioDataService = {
               operating_cash_flow: financialData?.operatingCashflow,
               free_cash_flow: financialData?.freeCashflow,
               cash_flow_growth: cashflowStatementHistory?.cashflowStatements[0]?.totalCashFromOperatingActivities,
+              // Add earnings data
+              earnings: quoteSummary.earnings ? {
+                maxAge: quoteSummary.earnings.maxAge,
+                earningsDate: quoteSummary.earnings.earningsDate,
+                earningsAverage: quoteSummary.earnings.earningsAverage,
+                earningsLow: quoteSummary.earnings.earningsLow,
+                earningsHigh: quoteSummary.earnings.earningsHigh,
+                earningsChart: {
+                  quarterly: quoteSummary.earnings.earningsChart.quarterly.map((q: { date: number; actual: number; estimate: number }) => ({
+                    date: q.date,
+                    actual: q.actual,
+                    estimate: q.estimate
+                  })),
+                  currentQuarterEstimate: quoteSummary.earnings.earningsChart.currentQuarterEstimate,
+                  currentQuarterEstimateDate: quoteSummary.earnings.earningsChart.currentQuarterEstimateDate,
+                  currentQuarterEstimateYear: quoteSummary.earnings.earningsChart.currentQuarterEstimateYear,
+                  earningsDate: quoteSummary.earnings.earningsChart.earningsDate,
+                  isEarningsDateEstimate: quoteSummary.earnings.earningsChart.isEarningsDateEstimate
+                },
+                financialsChart: {
+                  yearly: quoteSummary.earnings.financialsChart.yearly.map((y: { date: number; revenue: number; earnings: number }) => ({
+                    date: y.date,
+                    revenue: y.revenue,
+                    earnings: y.earnings
+                  })),
+                  quarterly: quoteSummary.earnings.financialsChart.quarterly.map((q: { date: number; revenue: number; earnings: number }) => ({
+                    date: q.date,
+                    revenue: q.revenue,
+                    earnings: q.earnings
+                  }))
+                },
+                financialCurrency: quoteSummary.earnings.financialCurrency
+              } : null,
               last_fetched: new Date().toISOString()
             })
             .eq('id', ps.security.id)

--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -54,6 +54,38 @@ export interface Security {
   operating_cash_flow: number;
   free_cash_flow: number;
   cash_flow_growth: number;
+  earnings?: {
+    maxAge: number;
+    earningsDate: number[];
+    earningsAverage: number;
+    earningsLow: number;
+    earningsHigh: number;
+    earningsChart: {
+      quarterly: {
+        date: number;
+        actual: number;
+        estimate: number;
+      }[];
+      currentQuarterEstimate: number;
+      currentQuarterEstimateDate: string;
+      currentQuarterEstimateYear: number;
+      earningsDate: number[];
+      isEarningsDateEstimate: boolean;
+    };
+    financialsChart: {
+      yearly: {
+        date: number;
+        revenue: number;
+        earnings: number;
+      }[];
+      quarterly: {
+        date: number;
+        revenue: number;
+        earnings: number;
+      }[];
+    };
+    financialCurrency: string;
+  };
   last_fetched: string;
 }
 

--- a/src/services/securityDataService.ts
+++ b/src/services/securityDataService.ts
@@ -112,6 +112,38 @@ export const securityService = {
         operating_cash_flow: quoteSummary.financialData?.operatingCashflow || 0,
         free_cash_flow: quoteSummary.financialData?.freeCashflow || 0,
         cash_flow_growth: quoteSummary.cashflowStatementHistory?.cashflowStatements[0]?.totalCashFromOperatingActivities || 0,
+        earnings: quoteSummary.earnings ? {
+          maxAge: quoteSummary.earnings.maxAge,
+          earningsDate: quoteSummary.earnings.earningsDate,
+          earningsAverage: quoteSummary.earnings.earningsAverage,
+          earningsLow: quoteSummary.earnings.earningsLow,
+          earningsHigh: quoteSummary.earnings.earningsHigh,
+          earningsChart: {
+            quarterly: quoteSummary.earnings.earningsChart.quarterly.map(q => ({
+              date: q.date,
+              actual: q.actual,
+              estimate: q.estimate
+            })),
+            currentQuarterEstimate: quoteSummary.earnings.earningsChart.currentQuarterEstimate,
+            currentQuarterEstimateDate: quoteSummary.earnings.earningsChart.currentQuarterEstimateDate,
+            currentQuarterEstimateYear: quoteSummary.earnings.earningsChart.currentQuarterEstimateYear,
+            earningsDate: quoteSummary.earnings.earningsChart.earningsDate,
+            isEarningsDateEstimate: quoteSummary.earnings.earningsChart.isEarningsDateEstimate
+          },
+          financialsChart: {
+            yearly: quoteSummary.earnings.financialsChart.yearly.map(y => ({
+              date: y.date,
+              revenue: y.revenue,
+              earnings: y.earnings
+            })),
+            quarterly: quoteSummary.earnings.financialsChart.quarterly.map(q => ({
+              date: q.date,
+              revenue: q.revenue,
+              earnings: q.earnings
+            }))
+          },
+          financialCurrency: quoteSummary.earnings.financialCurrency
+        } : undefined,
         last_fetched: new Date().toISOString()
       };
     } catch (error) {
@@ -171,6 +203,7 @@ export const securityService = {
           operating_cash_flow: updatedData.operating_cash_flow,
           free_cash_flow: updatedData.free_cash_flow,
           cash_flow_growth: updatedData.cash_flow_growth,
+          earnings: updatedData.earnings,
           last_fetched: new Date().toISOString()
         })
         .eq('id', securityId)

--- a/supabase/migrations/20240325000001_add_earnings_data.sql
+++ b/supabase/migrations/20240325000001_add_earnings_data.sql
@@ -1,0 +1,60 @@
+-- Add earnings data columns to securities table
+DO $$ 
+BEGIN
+    -- Add earnings data as JSONB column
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'earnings') THEN
+        ALTER TABLE public.securities ADD COLUMN earnings JSONB;
+    END IF;
+END $$;
+
+-- Update the trigger function to include earnings data
+DO $$ 
+BEGIN
+    -- Check if function exists
+    IF EXISTS (
+        SELECT 1 
+        FROM pg_proc 
+        WHERE proname = 'update_last_fetched' 
+        AND pronamespace = 'public'::regnamespace
+    ) THEN
+        -- Drop existing trigger if it exists
+        DROP TRIGGER IF EXISTS update_security_last_fetched ON public.securities;
+        
+        -- Create or replace the function
+        EXECUTE $func$
+        CREATE OR REPLACE FUNCTION update_last_fetched()
+        RETURNS TRIGGER AS $body$
+        BEGIN
+            -- Only update last_fetched if price-related fields are being updated
+            IF (
+                OLD.price IS DISTINCT FROM NEW.price OR
+                OLD.yield IS DISTINCT FROM NEW.yield OR
+                OLD.sma200 IS DISTINCT FROM NEW.sma200 OR
+                OLD.prev_close IS DISTINCT FROM NEW.prev_close OR
+                OLD.open IS DISTINCT FROM NEW.open OR
+                OLD.volume IS DISTINCT FROM NEW.volume OR
+                OLD.market_cap IS DISTINCT FROM NEW.market_cap OR
+                OLD.pe IS DISTINCT FROM NEW.pe OR
+                OLD.eps IS DISTINCT FROM NEW.eps OR
+                OLD.dividend IS DISTINCT FROM NEW.dividend OR
+                OLD.payout_ratio IS DISTINCT FROM NEW.payout_ratio OR
+                OLD.dividend_growth_5yr IS DISTINCT FROM NEW.dividend_growth_5yr OR
+                OLD.operating_cash_flow IS DISTINCT FROM NEW.operating_cash_flow OR
+                OLD.free_cash_flow IS DISTINCT FROM NEW.free_cash_flow OR
+                OLD.cash_flow_growth IS DISTINCT FROM NEW.cash_flow_growth OR
+                OLD.earnings IS DISTINCT FROM NEW.earnings
+            ) THEN
+                NEW.last_fetched = timezone('utc'::text, now());
+            END IF;
+            RETURN NEW;
+        END;
+        $body$ LANGUAGE plpgsql;
+        $func$;
+
+        -- Create trigger
+        CREATE TRIGGER update_security_last_fetched
+            BEFORE UPDATE ON public.securities
+            FOR EACH ROW
+            EXECUTE FUNCTION update_last_fetched();
+    END IF;
+END $$; 


### PR DESCRIPTION
This commit adds comprehensive earnings data integration across the application:

- Add earnings data to database schema
  - Create new migration (20240325000001) to add earnings JSONB column
  - Update last_fetched trigger to track earnings data changes

- Enhance Yahoo Finance client
  - Add robust date handling in transformEarnings method
  - Support multiple date formats (Date, timestamp, string)
  - Add null safety with fallback values

- Update API and services
  - Add earnings module to quotes API endpoint
  - Update Security and DatabaseSecurity interfaces
  - Integrate earnings data in portfolio and security services

- Add earnings UI components
  - Add earnings section to security detail page
  - Display next earnings estimates and ranges
  - Show quarterly and annual financials
  - Add historical earnings comparison
  - Update PriceDataTest component with earnings data

- Fix authentication
  - Add proper auth handling in quotes API
  - Update PriceDataTest to use Supabase auth

This completes the earnings data integration task from the financial API integration roadmap.