### PR TITLE
fix(portfolio): resolve TypeError when renaming portfolios

### DIFF
--- a/app/portfolios/[id]/portfolio-detail.tsx
+++ b/app/portfolios/[id]/portfolio-detail.tsx
@@ -84,7 +84,34 @@ export function PortfolioDetail({ portfolioId, initialPortfolio }: PortfolioDeta
   }, [initialPortfolio, fetchPortfolio, fetchSecurities]);
 
   const handlePortfolioUpdated = () => {
-    fetchPortfolio();
+    // Fetch the updated portfolio data but preserve existing securities
+    if (!session?.access_token) {
+      toast.error('You must be logged in to view portfolios');
+      return;
+    }
+
+    fetch(`/api/portfolios/${portfolioId}`, {
+      headers: {
+        'Authorization': `Bearer ${session.access_token}`,
+      },
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error('Failed to fetch updated portfolio');
+      }
+      return response.json();
+    })
+    .then(updatedPortfolio => {
+      // Preserve the existing securities data when updating the portfolio
+      setPortfolio(prev => prev ? {
+        ...updatedPortfolio,
+        securities: prev.securities || []
+      } : updatedPortfolio);
+    })
+    .catch(error => {
+      console.error('Error fetching updated portfolio:', error);
+      toast.error('Failed to fetch updated portfolio');
+    });
   };
 
   const handleSecurityDeleted = useCallback(() => {

--- a/components/portfolios/PortfolioHeader.tsx
+++ b/components/portfolios/PortfolioHeader.tsx
@@ -31,7 +31,7 @@ export function PortfolioHeader({ portfolio, onPortfolioUpdated }: PortfolioHead
         <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
           <div>
             <p className="text-sm font-medium text-muted-foreground">Securities</p>
-            <p className="text-2xl font-bold">{portfolio.securities.length}</p>
+            <p className="text-2xl font-bold">{portfolio.securities?.length || 0}</p>
           </div>
           <div>
             <p className="text-sm font-medium text-muted-foreground">Total Value</p>


### PR DESCRIPTION
- Fix 'Cannot read properties of undefined (reading length)' error in PortfolioHeader
- Preserve existing securities data during portfolio updates to prevent data loss
- Add safety check with optional chaining for portfolio.securities?.length
- Replace fetchPortfolio() call with targeted API fetch that maintains securities state
- Ensure portfolio state consistency during rename operations

Fixes issue where portfolio rename would clear securities data and cause runtime errors.