### PR TITLE
feat(dividends): improve dividend calendar UX, caching, and efficiency

### DIFF
--- a/app/api/dividends/route.ts
+++ b/app/api/dividends/route.ts
@@ -38,32 +38,114 @@ export async function GET(request: Request) {
     }
 
     // Fetch dividend history from Yahoo Finance using the client
-    const quoteSummary = await yahooFinanceClient.getQuoteSummary(ticker, [
-      'summaryDetail',
-      'defaultKeyStatistics'
-    ]);
+    console.log(`Fetching dividend data for ticker: ${ticker}`);
+    
+    try {
+      const quoteSummary = await yahooFinanceClient.getQuoteSummary(ticker, [
+        'summaryDetail',
+        'defaultKeyStatistics',
+        'calendarEvents'
+      ]);
 
-    const dividendRate = quoteSummary.summaryDetail?.dividendRate || 0;
-    const dividendYield = quoteSummary.summaryDetail?.dividendYield || 0;
-    const exDividendDate = quoteSummary.summaryDetail?.exDividendDate;
-    const payoutRatio = quoteSummary.summaryDetail?.payoutRatio || 0;
-    const fiveYearAvgDividendYield = quoteSummary.summaryDetail?.fiveYearAvgDividendYield || 0;
+      console.log(`Received quote summary for ${ticker}:`, {
+        hasSummaryDetail: !!quoteSummary.summaryDetail,
+        hasCalendarEvents: !!quoteSummary.calendarEvents,
+        summaryDetailKeys: quoteSummary.summaryDetail ? Object.keys(quoteSummary.summaryDetail) : [],
+        calendarEventsKeys: quoteSummary.calendarEvents ? Object.keys(quoteSummary.calendarEvents) : [],
+        dividendRate: quoteSummary.summaryDetail?.dividendRate,
+        dividendYield: quoteSummary.summaryDetail?.dividendYield,
+        exDividendDate: quoteSummary.summaryDetail?.exDividendDate,
+        calendarExDividendDate: quoteSummary.calendarEvents?.exDividendDate
+      });
 
-    // Calculate dividend growth rate
-    const dividendGrowth = fiveYearAvgDividendYield > 0 
-      ? ((dividendYield - fiveYearAvgDividendYield) / fiveYearAvgDividendYield) * 100 
-      : 0;
+      // Check if we have valid summary detail data
+      if (!quoteSummary.summaryDetail) {
+        console.warn(`No summary detail data available for ${ticker}`);
+        return NextResponse.json({
+          currentDividend: 0,
+          yield: 0,
+          exDividendDate: null,
+          payoutRatio: 0,
+          fiveYearAvgYield: 0,
+          growthRate: 0,
+        });
+      }
 
-    return NextResponse.json({
-      currentDividend: dividendRate,
-      yield: dividendYield * 100, // Convert to percentage
-      exDividendDate: exDividendDate ? new Date(Number(exDividendDate) * 1000).toISOString() : null,
-      payoutRatio: payoutRatio * 100, // Convert to percentage
-      fiveYearAvgYield: fiveYearAvgDividendYield * 100, // Convert to percentage
-      growthRate: dividendGrowth,
-    });
+      const dividendRate = quoteSummary.summaryDetail?.dividendRate || 0;
+      const dividendYield = quoteSummary.summaryDetail?.dividendYield || 0;
+      // Try to get exDividendDate from summaryDetail, then calendarEvents
+      let exDividendDate = quoteSummary.summaryDetail?.exDividendDate;
+      if (!exDividendDate && quoteSummary.calendarEvents?.exDividendDate) {
+        exDividendDate = quoteSummary.calendarEvents.exDividendDate;
+      }
+      const payoutRatio = quoteSummary.summaryDetail?.payoutRatio || 0;
+      const fiveYearAvgDividendYield = quoteSummary.summaryDetail?.fiveYearAvgDividendYield || 0;
+
+      // Calculate dividend growth rate
+      const dividendGrowth = fiveYearAvgDividendYield > 0 
+        ? ((dividendYield - fiveYearAvgDividendYield) / fiveYearAvgDividendYield) * 100 
+        : 0;
+
+      // Safely convert ex-dividend date
+      let formattedExDividendDate = null;
+      if (exDividendDate) {
+        try {
+          let timestamp = Number(exDividendDate);
+          if (!isNaN(timestamp) && timestamp > 0) {
+            // If timestamp is in milliseconds, convert to seconds
+            if (timestamp > 1e12) {
+              timestamp = Math.floor(timestamp / 1000);
+            }
+            const date = new Date(timestamp * 1000);
+            
+            // Validate the date is reasonable
+            if (!isNaN(date.getTime()) && date.getFullYear() >= 1900 && date.getFullYear() <= 2100) {
+              formattedExDividendDate = date.toISOString().split('T')[0]; // YYYY-MM-DD format
+            } else {
+              console.warn(`Invalid ex-dividend date for ${ticker}: ${exDividendDate} -> ${date}`);
+            }
+          } else {
+            console.warn(`Invalid timestamp for ${ticker}: ${exDividendDate}`);
+          }
+        } catch (error) {
+          console.warn(`Error parsing ex-dividend date for ${ticker}: ${exDividendDate}`, error);
+        }
+      }
+
+      return NextResponse.json({
+        currentDividend: dividendRate,
+        yield: dividendYield * 100, // Convert to percentage
+        exDividendDate: formattedExDividendDate,
+        payoutRatio: payoutRatio * 100, // Convert to percentage
+        fiveYearAvgYield: fiveYearAvgDividendYield * 100, // Convert to percentage
+        growthRate: dividendGrowth,
+      });
+    } catch (yahooError) {
+      const yahooErrorMessage = yahooError instanceof Error ? yahooError.message : String(yahooError);
+      console.error(`Yahoo Finance error for ${ticker}:`, {
+        error: yahooError,
+        message: yahooErrorMessage,
+        stack: yahooError instanceof Error ? yahooError.stack : undefined
+      });
+      
+      // Return default values instead of throwing an error
+      // This allows the process to continue with other securities
+      console.warn(`Returning default values for ${ticker} due to Yahoo Finance error`);
+      return NextResponse.json({
+        currentDividend: 0,
+        yield: 0,
+        exDividendDate: null,
+        payoutRatio: 0,
+        fiveYearAvgYield: 0,
+        growthRate: 0,
+      });
+    }
   } catch (error) {
-    console.error('Error fetching dividend data for ticker:', ticker, error);
+    console.error('Error fetching dividend data for ticker:', ticker, {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+      ticker
+    });
     
     // Provide more specific error messages based on the error type
     const errorMessage = error instanceof Error ? error.message : String(error);
@@ -83,7 +165,7 @@ export async function GET(request: Request) {
     }
     
     return NextResponse.json(
-      { error: 'Failed to fetch dividend data' },
+      { error: `Failed to fetch dividend data: ${errorMessage}` },
       { status: 500 }
     );
   }

--- a/app/portfolios/[id]/page.tsx
+++ b/app/portfolios/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { PortfolioDetail } from './portfolio-detail';
+import { PortfolioDetailSkeleton } from '@/components/portfolios/PortfolioDetailSkeleton';
 import { useEffect, useState } from 'react';
 
 interface PageProps {
@@ -14,9 +15,9 @@ export default function Page({ params }: PageProps) {
     params.then(({ id }) => setId(id));
   }, [params]);
 
-  // Show loading while params are being resolved
+  // Show skeleton while params are being resolved
   if (!id) {
-    return <div>Loading...</div>;
+    return <PortfolioDetailSkeleton />;
   }
 
   // Always pass initialPortfolio as null to force fresh data fetch

--- a/app/portfolios/[id]/portfolio-detail.tsx
+++ b/app/portfolios/[id]/portfolio-detail.tsx
@@ -306,13 +306,13 @@ export function PortfolioDetail({ portfolioId, initialPortfolio }: PortfolioDeta
 
         {/* Timing Tab */}
         <TabsContent value="timing" className="space-y-6">
+          {/* Dividend Calendar */}
+          <DividendCalendar portfolio={portfolio} />
+
           {/* Dividend Timing Dashboard - Expanded */}
           {analytics && (
             <DividendTimingDashboard portfolio={portfolio} />
           )}
-
-          {/* Dividend Calendar */}
-          <DividendCalendar portfolio={portfolio} />
         </TabsContent>
 
         {/* Securities Tab */}

--- a/app/portfolios/[id]/securities/[securityId]/page.tsx
+++ b/app/portfolios/[id]/securities/[securityId]/page.tsx
@@ -15,6 +15,7 @@ import { TechnicalIndicators } from '@/components/securities/technical-indicator
 import { DividendHistory } from '@/components/securities/dividend-history';
 import { AnalystRecommendations } from '@/components/securities/analyst-recommendations';
 import { BreadcrumbNav } from '@/components/ui/breadcrumb';
+import { SecurityDetailSkeleton } from '@/components/portfolios/SecurityDetailSkeleton';
 
 interface SecurityDetailPageProps {
   params: Promise<{ id: string; securityId: string }>;
@@ -114,7 +115,7 @@ export default function SecurityDetailPage({ params }: SecurityDetailPageProps) 
   }, [params]);
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <SecurityDetailSkeleton />;
   }
 
   if (!security) {

--- a/app/portfolios/create/page.tsx
+++ b/app/portfolios/create/page.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { useProfileCompletion } from '@/hooks/useProfileCompletion';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AlertCircle } from 'lucide-react';
+import { CreatePortfolioSkeleton } from '@/components/portfolios/CreatePortfolioSkeleton';
 
 export default function CreatePortfolioPage() {
   const router = useRouter();
@@ -62,7 +63,7 @@ export default function CreatePortfolioPage() {
   };
 
   if (profileLoading) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+    return <CreatePortfolioSkeleton />;
   }
 
   if (!isProfileComplete) {

--- a/components/portfolios/CreatePortfolioSkeleton.tsx
+++ b/components/portfolios/CreatePortfolioSkeleton.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function CreatePortfolioSkeleton() {
+  return (
+    <div className="container mx-auto py-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <Skeleton className="h-6 w-48" />
+          </CardTitle>
+          <CardDescription>
+            <Skeleton className="h-4 w-80" />
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <div>
+                <Skeleton className="h-4 w-24 mb-2" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+              <div>
+                <Skeleton className="h-4 w-24 mb-2" />
+                <Skeleton className="h-24 w-full" />
+              </div>
+            </div>
+            <div className="flex gap-4">
+              <Skeleton className="h-10 w-32" />
+              <Skeleton className="h-10 w-24" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+} 

--- a/components/portfolios/DividendCalendar.tsx
+++ b/components/portfolios/DividendCalendar.tsx
@@ -1,11 +1,16 @@
 "use client"
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, DollarSign, Clock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Calendar, DollarSign, Clock, RefreshCw, ChevronDown, ChevronRight } from 'lucide-react';
 import { Portfolio } from '@/services/portfolioService';
 import { dividendService } from '@/src/services/dividendService';
+import { toast } from 'sonner';
+import { supabase } from '@/lib/supabase';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import React from 'react';
 
 interface DividendEvent {
   date: string;
@@ -20,57 +25,252 @@ interface DividendCalendarProps {
   portfolio: Portfolio;
 }
 
+// Error Boundary for the calendar
+class CalendarErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean; error: any }> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+  static getDerivedStateFromError(error: any) {
+    return { hasError: true, error };
+  }
+  componentDidCatch(error: any, errorInfo: any) {
+    if (process.env.NODE_ENV === 'development') {
+      console.error('DividendCalendar error boundary caught:', error, errorInfo);
+    }
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-destructive">
+              <Calendar className="h-5 w-5" />
+              Dividend Calendar Error
+            </CardTitle>
+            <CardDescription>An error occurred while rendering the dividend calendar.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-destructive">{this.state.error?.message || 'Unknown error'}</div>
+          </CardContent>
+        </Card>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export function DividendCalendar({ portfolio }: DividendCalendarProps) {
   const [dividendEvents, setDividendEvents] = useState<DividendEvent[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [failedSecurities, setFailedSecurities] = useState<Array<{ ticker: string; error: string }>>([]);
+  const [expandedMonths, setExpandedMonths] = useState<Set<string>>(new Set());
 
-  useEffect(() => {
-    async function loadDividendEvents() {
-      try {
-        setLoading(true);
-        const dividends = await dividendService.getUpcomingDividends(portfolio);
-        
-        const events: DividendEvent[] = [];
-        
-        for (const dividend of dividends) {
-          const security = portfolio.securities.find(s => s.security.id === dividend.security_id);
-          if (security) {
-            const totalAmount = security.shares * dividend.amount;
-            
-            // Add ex-date event
-            events.push({
-              date: dividend.ex_date,
-              ticker: security.security.ticker,
-              amount: dividend.amount,
-              type: 'ex-date',
-              shares: security.shares,
-              totalAmount
-            });
-            
-            // Add payment event
-            events.push({
-              date: dividend.payment_date,
-              ticker: security.security.ticker,
-              amount: dividend.amount,
-              type: 'payment',
-              shares: security.shares,
-              totalAmount
-            });
-          }
+  const loadDividendEvents = useCallback(async () => {
+    try {
+      setLoading(true);
+      // Filter out 'Cash' securities before processing
+      const filteredPortfolio = {
+        ...portfolio,
+        securities: portfolio.securities.filter(s => s.security.ticker !== 'CASH'),
+      };
+      const dividends = await dividendService.getUpcomingDividends(filteredPortfolio);
+      
+      const events: DividendEvent[] = [];
+      
+      for (const dividend of dividends) {
+        const security = filteredPortfolio.securities.find(s => s.security.id === dividend.security_id);
+        if (security) {
+          const totalAmount = security.shares * dividend.amount;
+          
+          // Add ex-date event
+          events.push({
+            date: dividend.ex_date,
+            ticker: security.security.ticker,
+            amount: dividend.amount,
+            type: 'ex-date',
+            shares: security.shares,
+            totalAmount
+          });
+          
+          // Add payment event
+          events.push({
+            date: dividend.payment_date,
+            ticker: security.security.ticker,
+            amount: dividend.amount,
+            type: 'payment',
+            shares: security.shares,
+            totalAmount
+          });
         }
-        
-        // Sort by date
-        events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-        setDividendEvents(events);
-      } catch (error) {
-        console.error('Error loading dividend events:', error);
-      } finally {
-        setLoading(false);
       }
+      
+      // Sort by date
+      events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+      setDividendEvents(events);
+    } catch (error) {
+      // Defensive error handling
+      console.error('Error loading dividend events:', error);
+      setDividendEvents([]); // Ensure state is always set
+    } finally {
+      setLoading(false);
+    }
+  }, [portfolio]);
+
+  const populateDividendData = async (forceRefresh: boolean = false) => {
+    try {
+      setRefreshing(true);
+      toast.info(forceRefresh ? 'Force refreshing dividend data from Yahoo Finance...' : 'Fetching dividend data from Yahoo Finance...');
+      
+      // Call the dividend service to update portfolio dividend data
+      const result = await dividendService.updatePortfolioDividendData(portfolio, forceRefresh);
+      
+      // Reload the dividend events
+      await loadDividendEvents();
+      
+      // Show summary of results
+      const { results: updateResults } = result;
+      const successCount = updateResults.successful.length;
+      const failureCount = updateResults.failed.length;
+      const totalRecords = updateResults.totalDividendRecords;
+      
+      // Store failed securities for debugging
+      setFailedSecurities(updateResults.failed);
+
+      // Show upsert error if present
+      if (updateResults.upsertError) {
+        console.error('Dividends upsert error:', updateResults.upsertError);
+        toast.error('Failed to insert dividend data into the database.', {
+          description: updateResults.upsertError.message,
+          duration: 12000
+        });
+      }
+
+      // Show success/failure summary
+      if (successCount > 0) {
+        toast.success(`Updated ${successCount} securities successfully!`, {
+          description: failureCount > 0 ? `${failureCount} securities failed to update` : undefined,
+          duration: 5000
+        });
+      } else if (failureCount > 0) {
+        toast.error(`Failed to update ${failureCount} securities`, {
+          description: 'Check the debug button for details',
+          duration: 8000
+        });
+      } else {
+        toast.info('No securities needed updating (using cached data)', {
+          description: forceRefresh ? 'Force refresh completed' : 'Smart cache strategy applied',
+          duration: 3000
+        });
+      }
+
+      console.log('Dividend update completed:', {
+        successful: successCount,
+        failed: failureCount,
+        totalRecords,
+        forceRefresh
+      });
+      
+    } catch (error) {
+      console.error('Error populating dividend data:', error);
+      
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      toast.error(
+        'Failed to update dividend data. Please try again.',
+        {
+          description: errorMessage,
+          duration: 8000
+        }
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const debugFailedSecurities = async () => {
+    if (failedSecurities.length === 0) {
+      toast.info('No failed securities to debug');
+      return;
     }
 
+    try {
+      toast.info(`Debugging ${failedSecurities.length} failed securities...`);
+      
+      // Use the retry method from the service
+      const retryResults = await dividendService.retryFailedSecurities(failedSecurities);
+      
+      console.log('Retry results:', retryResults);
+      
+      if (retryResults.successful.length > 0) {
+        toast.success(`Retry successful for ${retryResults.successful.length} securities!`);
+        // Reload dividend events to show new data
+        await loadDividendEvents();
+      }
+      
+      if (retryResults.failed.length > 0) {
+        const stillFailed = retryResults.failed.map(f => f.ticker).join(', ');
+        toast.error(`Still failed: ${stillFailed}`);
+        
+        // Update the failed securities list
+        setFailedSecurities(retryResults.failed);
+      }
+      
+      // Also try direct API calls for detailed debugging
+      for (const failed of failedSecurities) {
+        console.log(`Direct API debug for ${failed.ticker}:`, failed.error);
+        
+        try {
+          const response = await fetch(`/api/dividends?ticker=${failed.ticker}`, {
+            headers: {
+              'Authorization': `Bearer ${(await supabase.auth.getSession()).data.session?.access_token}`
+            }
+          });
+          
+          const data = await response.json();
+          console.log(`Direct API result for ${failed.ticker}:`, {
+            status: response.status,
+            data: data
+          });
+          
+        } catch (debugError) {
+          console.error(`Direct API debug error for ${failed.ticker}:`, debugError);
+        }
+        
+        // Add delay between requests
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+      
+    } catch (error) {
+      console.error('Error debugging failed securities:', error);
+      toast.error('Error during debugging');
+    }
+  };
+
+  useEffect(() => {
     loadDividendEvents();
-  }, [portfolio]);
+  }, [loadDividendEvents]);
+
+  // Initialize expanded months - only current month expanded by default
+  useEffect(() => {
+    if (dividendEvents.length > 0) {
+      const today = new Date();
+      const currentMonthKey = `${today.getFullYear()}-${today.getMonth()}`;
+      setExpandedMonths(new Set([currentMonthKey]));
+    }
+  }, [dividendEvents]);
+
+  const toggleMonth = (monthKey: string) => {
+    setExpandedMonths(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(monthKey)) {
+        newSet.delete(monthKey);
+      } else {
+        newSet.add(monthKey);
+      }
+      return newSet;
+    });
+  };
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -105,125 +305,224 @@ export function DividendCalendar({ portfolio }: DividendCalendarProps) {
     return type === 'ex-date' ? <Clock className="h-3 w-3" /> : <DollarSign className="h-3 w-3" />;
   };
 
-  if (loading) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Calendar className="h-5 w-5" />
-            Dividend Calendar
-          </CardTitle>
-          <CardDescription>Upcoming dividend events</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-            <p className="text-muted-foreground mt-2">Loading calendar...</p>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  if (dividendEvents.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Calendar className="h-5 w-5" />
-            Dividend Calendar
-          </CardTitle>
-          <CardDescription>Upcoming dividend events</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="text-center py-8">
-            <Calendar className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <p className="text-muted-foreground">No upcoming dividend events</p>
-            <p className="text-sm text-muted-foreground mt-1">
-              Add dividend-paying stocks to see calendar events
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // Group events by month
-  const eventsByMonth = dividendEvents.reduce((acc, event) => {
-    const date = new Date(event.date);
-    const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
-    const monthName = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-    
-    if (!acc[monthKey]) {
-      acc[monthKey] = {
-        monthName,
-        events: []
-      };
-    }
-    
-    acc[monthKey].events.push(event);
-    return acc;
-  }, {} as Record<string, { monthName: string; events: DividendEvent[] }>);
-
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Calendar className="h-5 w-5" />
-          Dividend Calendar
-        </CardTitle>
-        <CardDescription>Upcoming dividend events and payments</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-6">
-          {Object.entries(eventsByMonth).map(([monthKey, monthData]) => (
-            <div key={monthKey} className="space-y-3">
-              <h3 className="font-semibold text-lg border-b pb-2">{monthData.monthName}</h3>
-              <div className="space-y-3">
-                {monthData.events.map((event, index) => {
-                  const daysUntil = getDaysUntil(event.date);
-                  const isUpcoming = daysUntil >= 0;
-                  
-                  return (
-                    <div key={`${event.date}-${event.ticker}-${event.type}-${index}`} 
-                         className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors">
-                      <div className="flex items-center gap-3">
-                        <div className={`p-2 rounded-full ${getEventColor(event.type)}`}>
-                          {getEventIcon(event.type)}
-                        </div>
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <span className="font-medium">{event.ticker}</span>
-                            <Badge variant={event.type === 'ex-date' ? 'secondary' : 'default'}>
-                              {event.type === 'ex-date' ? 'Ex-Date' : 'Payment'}
-                            </Badge>
-                          </div>
-                          <div className="text-sm text-muted-foreground">
-                            {formatDate(event.date)}
-                          </div>
-                        </div>
-                      </div>
-                      <div className="text-right">
-                        <div className="font-medium">
-                          {formatCurrency(event.totalAmount)}
-                        </div>
-                        <div className="text-sm text-muted-foreground">
-                          {event.shares} shares @ {formatCurrency(event.amount)}
-                        </div>
-                        {isUpcoming && (
-                          <div className="text-xs text-muted-foreground">
-                            {daysUntil === 0 ? 'Today' : `${daysUntil} days`}
-                          </div>
+    <CalendarErrorBoundary>
+      {/* Defensive: check for null/undefined dividendEvents and failedSecurities */}
+      {loading ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              Dividend Calendar
+            </CardTitle>
+            <CardDescription>Upcoming dividend events</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="text-center py-8">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+              <p className="text-muted-foreground mt-2">Loading calendar...</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (!dividendEvents || dividendEvents.length === 0) ? (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  <Calendar className="h-5 w-5" />
+                  Dividend Calendar
+                </CardTitle>
+                <CardDescription>Upcoming dividend events</CardDescription>
+              </div>
+              <div className="flex gap-2">
+                {failedSecurities.length > 0 && (
+                  <Button 
+                    onClick={debugFailedSecurities} 
+                    size="sm"
+                    variant="destructive"
+                    title={`Debug ${failedSecurities.length} failed securities`}
+                  >
+                    Debug ({failedSecurities.length})
+                  </Button>
+                )}
+                <Button 
+                  onClick={() => populateDividendData(false)} 
+                  disabled={refreshing}
+                  size="sm"
+                  variant="outline"
+                >
+                  {refreshing ? (
+                    <RefreshCw className="h-4 w-4 animate-spin mr-2" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                  )}
+                  Smart Refresh
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="text-center py-8">
+              <Calendar className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <p className="text-muted-foreground">No upcoming dividend events</p>
+              <p className="text-sm text-muted-foreground mt-1 mb-4">
+                Click &quot;Fetch Dividends&quot; to populate calendar with data from Yahoo Finance
+              </p>
+              <div className="flex gap-2 justify-center">
+                {failedSecurities.length > 0 && (
+                  <Button 
+                    onClick={debugFailedSecurities} 
+                    disabled={refreshing}
+                    variant="destructive"
+                    size="sm"
+                  >
+                    Debug ({failedSecurities.length})
+                  </Button>
+                )}
+                <Button 
+                  onClick={() => populateDividendData(false)} 
+                  disabled={refreshing}
+                  className="flex-1"
+                >
+                  {refreshing ? (
+                    <>
+                      <RefreshCw className="h-4 w-4 animate-spin mr-2" />
+                      Fetching Dividend Data...
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Smart Refresh
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  <Calendar className="h-5 w-5" />
+                  Dividend Calendar
+                </CardTitle>
+                <CardDescription>Upcoming dividend events and payments</CardDescription>
+              </div>
+              <div className="flex gap-2">
+                {failedSecurities.length > 0 && (
+                  <Button 
+                    onClick={debugFailedSecurities} 
+                    size="sm"
+                    variant="destructive"
+                    title={`Debug ${failedSecurities.length} failed securities`}
+                  >
+                    Debug ({failedSecurities.length})
+                  </Button>
+                )}
+                <Button 
+                  onClick={() => populateDividendData(false)} 
+                  disabled={refreshing}
+                  size="sm"
+                  variant="outline"
+                >
+                  {refreshing ? (
+                    <RefreshCw className="h-4 w-4 animate-spin mr-2" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                  )}
+                  Smart Refresh
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-6">
+              {Object.entries(dividendEvents.reduce((acc, event) => {
+                const date = new Date(event.date);
+                const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
+                const monthName = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+                
+                if (!acc[monthKey]) {
+                  acc[monthKey] = {
+                    monthName,
+                    events: []
+                  };
+                }
+                
+                acc[monthKey].events.push(event);
+                return acc;
+              }, {} as Record<string, { monthName: string; events: DividendEvent[] }>)).map(([monthKey, monthData]) => (
+                <Collapsible 
+                  key={monthKey} 
+                  open={expandedMonths.has(monthKey)}
+                  onOpenChange={() => toggleMonth(monthKey)}
+                >
+                  <CollapsibleTrigger asChild>
+                    <div className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors cursor-pointer">
+                      <h3 className="font-semibold text-lg">{monthData.monthName}</h3>
+                      <div className="flex items-center gap-2">
+                        <Badge variant="secondary">{monthData.events.length} events</Badge>
+                        {expandedMonths.has(monthKey) ? (
+                          <ChevronDown className="h-4 w-4" />
+                        ) : (
+                          <ChevronRight className="h-4 w-4" />
                         )}
                       </div>
                     </div>
-                  );
-                })}
-              </div>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="space-y-3 mt-3">
+                      {monthData.events.map((event, index) => {
+                        const daysUntil = getDaysUntil(event.date);
+                        const isUpcoming = daysUntil >= 0;
+                        
+                        return (
+                          <div key={`${event.date}-${event.ticker}-${event.type}-${index}`} 
+                               className="flex items-center justify-between p-3 border rounded-lg hover:bg-muted/50 transition-colors">
+                            <div className="flex items-center gap-3">
+                              <div className={`p-2 rounded-full ${getEventColor(event.type)}`}>
+                                {getEventIcon(event.type)}
+                              </div>
+                              <div>
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium">{event.ticker}</span>
+                                  <Badge variant={event.type === 'ex-date' ? 'secondary' : 'default'}>
+                                    {event.type === 'ex-date' ? 'Ex-Date' : 'Payment'}
+                                  </Badge>
+                                </div>
+                                <div className="text-sm text-muted-foreground">
+                                  {formatDate(event.date)}
+                                </div>
+                              </div>
+                            </div>
+                            <div className="text-right">
+                              <div className="font-medium">
+                                {formatCurrency(event.totalAmount)}
+                              </div>
+                              <div className="text-sm text-muted-foreground">
+                                {event.shares} shares @ {formatCurrency(event.amount)}
+                              </div>
+                              {isUpcoming && (
+                                <div className="text-xs text-muted-foreground">
+                                  {daysUntil === 0 ? 'Today' : `${daysUntil} days`}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              ))}
             </div>
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+          </CardContent>
+        </Card>
+      )}
+    </CalendarErrorBoundary>
   );
 } 

--- a/components/portfolios/SecurityDetailSkeleton.tsx
+++ b/components/portfolios/SecurityDetailSkeleton.tsx
@@ -1,0 +1,94 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+
+export function SecurityDetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Header Skeleton */}
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-6 w-16" />
+          </div>
+          <Skeleton className="h-6 w-48" />
+        </div>
+        
+        <div className="flex flex-col items-end">
+          <Skeleton className="h-8 w-24 mb-2" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-4 w-40 mt-1" />
+        </div>
+      </div>
+      
+      {/* Action Buttons Skeleton */}
+      <div className="flex justify-between gap-4 overflow-auto whitespace-nowrap rounded-lg border p-1">
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-32" />
+        ))}
+      </div>
+      
+      {/* Cards Grid Skeleton */}
+      <div className="grid gap-6 md:grid-cols-3">
+        {[...Array(3)].map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base flex items-center">
+                <Skeleton className="h-4 w-4 mr-2" />
+                <Skeleton className="h-4 w-24" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-2 text-sm">
+              {[...Array(6)].map((_, j) => (
+                <div key={j}>
+                  <Skeleton className="h-3 w-16 mb-1" />
+                  <Skeleton className="h-4 w-20" />
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      
+      {/* Tabs Skeleton */}
+      <div className="flex gap-4">
+        {[...Array(4)].map((_, i) => (
+          <Skeleton key={i} className="h-10 w-24" />
+        ))}
+      </div>
+      
+      {/* Main Content Skeleton */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-7">
+        <Card className="col-span-4">
+          <CardHeader>
+            <CardTitle>
+              <Skeleton className="h-6 w-24" />
+            </CardTitle>
+            <Skeleton className="h-4 w-32" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+        <Card className="col-span-3">
+          <CardHeader>
+            <CardTitle>
+              <Skeleton className="h-6 w-32" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[...Array(4)].map((_, i) => (
+                <div key={i} className="space-y-2">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-6 w-32" />
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+} 

--- a/lib/financial/api/yahoo/config.ts
+++ b/lib/financial/api/yahoo/config.ts
@@ -34,6 +34,7 @@ export const YAHOO_FINANCE_CONFIG = {
     'price',
     'summaryDetail',
     'defaultKeyStatistics',
+    'calendarEvents',
   ] as const,
 
   // Error handling
@@ -47,4 +48,13 @@ export const YAHOO_FINANCE_CONFIG = {
   },
 } as const;
 
-export type YahooFinanceModule = typeof YAHOO_FINANCE_CONFIG.defaultModules[number]; 
+export type YahooFinanceModule =
+  | 'assetProfile'
+  | 'balanceSheetHistory'
+  | 'cashflowStatementHistory'
+  | 'earnings'
+  | 'financialData'
+  | 'price'
+  | 'summaryDetail'
+  | 'defaultKeyStatistics'
+  | 'calendarEvents'; 

--- a/lib/financial/api/yahoo/types.ts
+++ b/lib/financial/api/yahoo/types.ts
@@ -4,6 +4,13 @@ export interface YahooFinanceError {
   description?: string;
 }
 
+export interface CalendarEvents {
+  exDividendDate?: number;
+  dividendDate?: number;
+  earnings?: Array<{ raw: number; fmt: string }>;
+  earningsDate?: Array<{ raw: number; fmt: string }>;
+}
+
 export interface QuoteSummary {
   assetProfile?: AssetProfile;
   balanceSheetHistory?: BalanceSheetHistory;
@@ -12,6 +19,7 @@ export interface QuoteSummary {
   financialData?: FinancialData;
   price?: Price;
   summaryDetail?: SummaryDetail;
+  calendarEvents?: CalendarEvents;
 }
 
 export interface AssetProfile {

--- a/src/services/dividendService.ts
+++ b/src/services/dividendService.ts
@@ -133,11 +133,14 @@ export const dividendService = {
   },
 
   async getUpcomingDividends(portfolio: Portfolio) {
+    // Filter out 'Cash' securities
+    const filteredSecurities = portfolio.securities.filter(s => s.security.ticker !== 'CASH');
+    const filteredPortfolio = { ...portfolio, securities: filteredSecurities };
     const today = new Date();
     const { data: dividends, error } = await supabase
       .from('dividends')
       .select('*')
-      .in('security_id', portfolio.securities.map(s => s.security.id))
+      .in('security_id', filteredPortfolio.securities.map(s => s.security.id))
       .gte('ex_date', today.toISOString())
       .order('ex_date', { ascending: true });
 
@@ -187,10 +190,22 @@ export const dividendService = {
   async fetchDividendData(ticker: string) {
     try {
       // Get the current session
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) {
-        throw new Error('No active session');
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      
+      if (sessionError) {
+        console.error('Session error:', sessionError);
+        throw new Error(`Session error: ${sessionError.message}`);
       }
+      
+      if (!session) {
+        throw new Error('No active session - user not authenticated');
+      }
+
+      if (!session.access_token) {
+        throw new Error('No access token in session');
+      }
+
+      console.log(`Making API request for ${ticker} with token:`, session.access_token.substring(0, 10) + '...');
 
       const response = await fetch(`/api/dividends?ticker=${ticker}`, {
         headers: {
@@ -198,14 +213,57 @@ export const dividendService = {
         }
       });
 
+      console.log(`API response for ${ticker}:`, {
+        status: response.status,
+        statusText: response.statusText,
+        ok: response.ok
+      });
+
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to fetch dividend data');
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
+        console.error(`API error for ${ticker}:`, errorData);
+        throw new Error(errorData.error || `HTTP ${response.status}: ${response.statusText}`);
       }
 
-      return await response.json();
+      const data = await response.json();
+      
+      // Validate that we got the expected data structure
+      if (!data || typeof data !== 'object') {
+        throw new Error('Invalid response format from dividend API');
+      }
+
+      // Validate and sanitize the ex-dividend date
+      if (data.exDividendDate) {
+        try {
+          const exDate = new Date(data.exDividendDate);
+          if (isNaN(exDate.getTime()) || exDate.getFullYear() < 1900 || exDate.getFullYear() > 2100) {
+            console.warn(`Invalid ex-dividend date for ${ticker}: ${data.exDividendDate}, setting to null`);
+            data.exDividendDate = null;
+          } else {
+            // Convert to ISO date string (YYYY-MM-DD)
+            data.exDividendDate = exDate.toISOString().split('T')[0];
+          }
+        } catch (error) {
+          console.warn(`Error parsing ex-dividend date for ${ticker}: ${data.exDividendDate}, setting to null`);
+          data.exDividendDate = null;
+        }
+      }
+
+      console.log(`Successfully fetched data for ${ticker}:`, {
+        currentDividend: data.currentDividend,
+        yield: data.yield,
+        hasExDate: !!data.exDividendDate,
+        exDate: data.exDividendDate
+      });
+
+      return data;
     } catch (error) {
-      console.error('Error fetching dividend data:', error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(`Error fetching dividend data for ${ticker}:`, {
+        message: errorMessage,
+        type: error instanceof Error ? 'Error' : typeof error,
+        ticker
+      });
       throw error;
     }
   },
@@ -239,17 +297,328 @@ export const dividendService = {
     }
   },
 
-  async updatePortfolioDividendData(portfolio: Portfolio) {
+  async updatePortfolioDividendData(portfolio: Portfolio, forceRefresh: boolean = false) {
+    const results = {
+      successful: [] as string[],
+      failed: [] as Array<{ ticker: string; error: string }>,
+      totalDividendRecords: 0,
+      upsertError: null as null | { message: string; details?: any; data?: any }
+    };
+
     try {
-      const updates = portfolio.securities.map(async (security) => {
-        return this.updateSecurityDividendData(security.security.id, security.security.ticker);
+      const allDividendData: Array<{
+        security_id: string;
+        amount: number;
+        ex_date: string;
+        payment_date: string;
+      }> = [];
+
+      console.log(`Starting dividend data update for portfolio with ${portfolio.securities.length} securities`);
+
+      // Filter securities that need refreshing based on smart cache strategy
+      const securitiesToUpdate = portfolio.securities.filter(security => 
+        this.shouldRefreshDividendData(security.security, forceRefresh)
+      );
+
+      console.log(`Smart cache strategy: ${securitiesToUpdate.length}/${portfolio.securities.length} securities need updating`);
+
+      // Process each security that needs updating
+      for (const security of securitiesToUpdate) {
+        try {
+          console.log(`Processing security: ${security.security.ticker} (ID: ${security.security.id})`);
+          
+          // Add a small delay between requests to avoid rate limiting
+          await new Promise(resolve => setTimeout(resolve, 100));
+          
+          const dividendData = await this.fetchDividendData(security.security.ticker);
+          
+          console.log(`Fetched dividend data for ${security.security.ticker}:`, {
+            currentDividend: dividendData.currentDividend,
+            yield: dividendData.yield,
+            exDividendDate: dividendData.exDividendDate,
+            payoutRatio: dividendData.payoutRatio,
+            growthRate: dividendData.growthRate,
+            fiveYearAvgYield: dividendData.fiveYearAvgYield
+          });
+
+          // Update the security's dividend information in the database
+          const { error: updateError } = await supabase
+            .from('securities')
+            .update({
+              dividend: dividendData.currentDividend,
+              yield: dividendData.yield,
+              ex_dividend_date: dividendData.exDividendDate,
+              payout_ratio: dividendData.payoutRatio,
+              dividend_growth_5yr: dividendData.growthRate,
+              five_year_avg_yield: dividendData.fiveYearAvgYield,
+              updated_at: new Date().toISOString()
+            })
+            .eq('id', security.security.id);
+
+          if (updateError) {
+            throw updateError;
+          }
+
+          results.successful.push(security.security.ticker);
+
+          // Generate future dividend dates if we have ex-dividend date and dividend rate
+          if (dividendData.exDividendDate && dividendData.currentDividend > 0) {
+            console.log(`Generating future dividends for ${security.security.ticker} with ex-date: ${dividendData.exDividendDate}`);
+            const futureDividends = this.generateFutureDividendDates(
+              security.security.id,
+              dividendData.exDividendDate,
+              dividendData.currentDividend
+            );
+            console.log(`Generated ${futureDividends.length} future dividend dates for ${security.security.ticker}`);
+            allDividendData.push(...futureDividends);
+          } else {
+            console.log(`Skipping future dividend generation for ${security.security.ticker} - no ex-date or dividend rate`);
+          }
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          console.error(`Error processing security ${security.security.ticker}:`, {
+            message: errorMessage,
+            type: error instanceof Error ? 'Error' : typeof error,
+            ticker: security.security.ticker,
+            error: error
+          });
+          
+          // Log detailed error information for any problematic ticker
+          console.error(`Detailed error for ${security.security.ticker}:`, {
+            error,
+            stack: error instanceof Error ? error.stack : undefined,
+            message: errorMessage,
+            securityId: security.security.id
+          });
+          
+          results.failed.push({
+            ticker: security.security.ticker,
+            error: errorMessage
+          });
+          continue; // Continue with next security
+        }
+      }
+
+      console.log(`Total dividend data to insert: ${allDividendData.length} records`);
+      results.totalDividendRecords = allDividendData.length;
+
+      // Insert all dividend data into the database
+      if (allDividendData.length > 0) {
+        console.log('Inserting dividend data into database...');
+        console.log('Dividend data to upsert:', allDividendData);
+        
+        // Use a batch insert approach to handle potential conflicts
+        const { error: insertError, data: insertData } = await supabase
+          .from('dividends')
+          .upsert(allDividendData, {
+            onConflict: 'security_id,ex_date',
+            ignoreDuplicates: false
+          });
+
+        if (insertError) {
+          console.error('Error inserting dividend data:', {
+            error: insertError,
+            message: insertError.message,
+            details: insertError.details,
+            hint: insertError.hint,
+            code: insertError.code,
+            data: allDividendData
+          });
+          // Surface the error in the results object for UI display
+          results.upsertError = {
+            message: insertError.message || insertError.details || 'Unknown database error',
+            details: insertError,
+            data: allDividendData
+          };
+          // Don't throw here - we want to return partial results
+          console.warn('Failed to insert dividend data, but continuing with partial results');
+        } else {
+          console.log('Successfully inserted dividend data into database:', insertData);
+        }
+      } else {
+        console.log('No dividend data to insert');
+      }
+
+      console.log('Calculating dividend metrics...');
+      const metrics = this.calculateDividendMetrics(portfolio);
+      
+      // Log summary
+      console.log('Dividend update summary:', {
+        successful: results.successful.length,
+        failed: results.failed.length,
+        totalDividendRecords: results.totalDividendRecords,
+        successfulTickers: results.successful,
+        failedTickers: results.failed.map(f => f.ticker),
+        upsertError: results.upsertError
       });
 
-      await Promise.all(updates);
-      return this.calculateDividendMetrics(portfolio);
+      return {
+        metrics,
+        results
+      };
     } catch (error) {
-      console.error('Error updating portfolio dividend data:', error);
-      throw error;
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('Error updating portfolio dividend data:', {
+        message: errorMessage,
+        type: error instanceof Error ? 'Error' : typeof error,
+        error: error
+      });
+      
+      // Create a more descriptive error message
+      const descriptiveError = new Error(`Failed to update portfolio dividend data: ${errorMessage}`);
+      throw descriptiveError;
     }
-  }
+  },
+
+  generateFutureDividendDates(
+    securityId: string,
+    baseExDate: string,
+    annualDividendRate: number,
+    monthsAhead: number = 12
+  ): Array<{
+    security_id: string;
+    amount: number;
+    ex_date: string;
+    payment_date: string;
+  }> {
+    const dividendData: Array<{
+      security_id: string;
+      amount: number;
+      ex_date: string;
+      payment_date: string;
+    }> = [];
+    
+    const baseDate = new Date(baseExDate);
+    
+    // Most dividend-paying stocks pay quarterly (every 3 months)
+    // Some pay monthly, semi-annually, or annually
+    // We'll assume quarterly for now, but this could be enhanced with actual frequency data
+    
+    for (let i = 0; i < monthsAhead; i += 3) {
+      const exDate = new Date(baseDate);
+      exDate.setMonth(exDate.getMonth() + i);
+      
+      // Skip if the date is in the past
+      if (exDate <= new Date()) {
+        continue;
+      }
+      
+      const paymentDate = new Date(exDate);
+      paymentDate.setDate(paymentDate.getDate() + 21); // 21 days after ex-date
+      
+      dividendData.push({
+        security_id: securityId,
+        amount: annualDividendRate / 4, // Quarterly dividend (annual rate / 4)
+        ex_date: exDate.toISOString().split('T')[0],
+        payment_date: paymentDate.toISOString().split('T')[0]
+      });
+    }
+    
+    return dividendData;
+  },
+
+  async retryFailedSecurities(failedSecurities: Array<{ ticker: string; error: string }>) {
+    const results = {
+      successful: [] as string[],
+      failed: [] as Array<{ ticker: string; error: string }>,
+      totalDividendRecords: 0
+    };
+
+    console.log(`Retrying ${failedSecurities.length} failed securities...`);
+
+    for (const failed of failedSecurities) {
+      try {
+        console.log(`Retrying ${failed.ticker}...`);
+        
+        // Add a longer delay for retries
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+        const dividendData = await this.fetchDividendData(failed.ticker);
+        
+        console.log(`Retry successful for ${failed.ticker}:`, {
+          currentDividend: dividendData.currentDividend,
+          yield: dividendData.yield,
+          exDividendDate: dividendData.exDividendDate
+        });
+        
+        results.successful.push(failed.ticker);
+        
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(`Retry failed for ${failed.ticker}:`, errorMessage);
+        results.failed.push({
+          ticker: failed.ticker,
+          error: errorMessage
+        });
+      }
+    }
+
+    return results;
+  },
+
+  /**
+   * Smart cache strategy for dividend data updates
+   * Determines when to refresh vs use cache based on multiple factors
+   */
+  shouldRefreshDividendData(security: any, forceRefresh: boolean = false): boolean {
+    if (forceRefresh) return true;
+
+    const now = new Date();
+    const lastFetched = security.last_fetched ? new Date(security.last_fetched) : null;
+    
+    // If never fetched, always refresh
+    if (!lastFetched) return true;
+
+    const timeSinceLastFetch = now.getTime() - lastFetched.getTime();
+    const fiveMinutes = 5 * 60 * 1000;
+    const oneHour = 60 * 60 * 1000;
+
+    // Check if within 5 minutes (use cache)
+    if (timeSinceLastFetch < fiveMinutes) {
+      return false;
+    }
+
+    // Check if it's market hours (9:30 AM - 4:00 PM ET)
+    const isMarketHours = this.isMarketHours(now);
+    
+    // Check if approaching ex-dividend date (within 2 weeks)
+    const isApproachingExDate = this.isApproachingExDividendDate(security);
+
+    // Refresh if:
+    // 1. More than 1 hour old during market hours
+    // 2. Approaching ex-dividend date
+    // 3. More than 24 hours old regardless
+    return (
+      (isMarketHours && timeSinceLastFetch > oneHour) ||
+      isApproachingExDate ||
+      timeSinceLastFetch > 24 * 60 * 60 * 1000
+    );
+  },
+
+  /**
+   * Check if current time is during market hours (9:30 AM - 4:00 PM ET)
+   */
+  isMarketHours(date: Date): boolean {
+    // Convert to Eastern Time
+    const easternTime = new Date(date.toLocaleString("en-US", {timeZone: "America/New_York"}));
+    const hours = easternTime.getHours();
+    const minutes = easternTime.getMinutes();
+    const timeInMinutes = hours * 60 + minutes;
+    
+    // Market hours: 9:30 AM (570 minutes) to 4:00 PM (960 minutes)
+    return timeInMinutes >= 570 && timeInMinutes <= 960;
+  },
+
+  /**
+   * Check if security is approaching its ex-dividend date (within 2 weeks)
+   */
+  isApproachingExDividendDate(security: any): boolean {
+    if (!security.ex_dividend_date) return false;
+    
+    const exDate = new Date(security.ex_dividend_date);
+    const now = new Date();
+    const twoWeeks = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
+    
+    return exDate.getTime() - now.getTime() <= twoWeeks;
+  },
 }; 

--- a/supabase/migrations/20240321000008_add_dividend_unique_constraint.sql
+++ b/supabase/migrations/20240321000008_add_dividend_unique_constraint.sql
@@ -1,0 +1,13 @@
+-- Add unique constraint to prevent duplicate dividend entries for the same security and ex-date
+-- This migration is idempotent - it will not fail if the constraint already exists
+DO $$ 
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'unique_security_ex_date'
+    ) THEN
+        ALTER TABLE dividends 
+        ADD CONSTRAINT unique_security_ex_date 
+        UNIQUE (security_id, ex_date);
+    END IF;
+END $$; 

--- a/supabase/migrations/20240321000009_add_dividend_columns.sql
+++ b/supabase/migrations/20240321000009_add_dividend_columns.sql
@@ -1,0 +1,115 @@
+-- Add missing columns to securities table
+-- This migration is idempotent - it will not fail if columns already exist
+
+DO $$ 
+BEGIN
+    -- Add dividend-related columns
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'dividend_growth_5yr') THEN
+        ALTER TABLE securities ADD COLUMN dividend_growth_5yr DECIMAL(5,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'payout_ratio') THEN
+        ALTER TABLE securities ADD COLUMN payout_ratio DECIMAL(5,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'five_year_avg_yield') THEN
+        ALTER TABLE securities ADD COLUMN five_year_avg_yield DECIMAL(5,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'ex_dividend_date') THEN
+        ALTER TABLE securities ADD COLUMN ex_dividend_date DATE;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'dividend') THEN
+        ALTER TABLE securities ADD COLUMN dividend DECIMAL(10,4);
+    END IF;
+
+    -- Add missing basic columns
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'prev_close') THEN
+        ALTER TABLE securities ADD COLUMN prev_close DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'open') THEN
+        ALTER TABLE securities ADD COLUMN open DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'volume') THEN
+        ALTER TABLE securities ADD COLUMN volume BIGINT;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'market_cap') THEN
+        ALTER TABLE securities ADD COLUMN market_cap BIGINT;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'pe') THEN
+        ALTER TABLE securities ADD COLUMN pe DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'eps') THEN
+        ALTER TABLE securities ADD COLUMN eps DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'industry') THEN
+        ALTER TABLE securities ADD COLUMN industry TEXT;
+    END IF;
+
+    -- Add technical analysis columns
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'day_low') THEN
+        ALTER TABLE securities ADD COLUMN day_low DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'day_high') THEN
+        ALTER TABLE securities ADD COLUMN day_high DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'fifty_two_week_low') THEN
+        ALTER TABLE securities ADD COLUMN fifty_two_week_low DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'fifty_two_week_high') THEN
+        ALTER TABLE securities ADD COLUMN fifty_two_week_high DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'average_volume') THEN
+        ALTER TABLE securities ADD COLUMN average_volume BIGINT;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'forward_pe') THEN
+        ALTER TABLE securities ADD COLUMN forward_pe DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'price_to_sales_trailing_12_months') THEN
+        ALTER TABLE securities ADD COLUMN price_to_sales_trailing_12_months DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'beta') THEN
+        ALTER TABLE securities ADD COLUMN beta DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'fifty_day_average') THEN
+        ALTER TABLE securities ADD COLUMN fifty_day_average DECIMAL(10,2);
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'two_hundred_day_average') THEN
+        ALTER TABLE securities ADD COLUMN two_hundred_day_average DECIMAL(10,2);
+    END IF;
+
+    -- Add financial data columns
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'operating_cash_flow') THEN
+        ALTER TABLE securities ADD COLUMN operating_cash_flow BIGINT;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'free_cash_flow') THEN
+        ALTER TABLE securities ADD COLUMN free_cash_flow BIGINT;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'cash_flow_growth') THEN
+        ALTER TABLE securities ADD COLUMN cash_flow_growth BIGINT;
+    END IF;
+
+    -- Add earnings data column (JSONB for complex earnings data)
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'securities' AND column_name = 'earnings') THEN
+        ALTER TABLE securities ADD COLUMN earnings JSONB;
+    END IF;
+
+END $$; 

--- a/supabase/migrations/20240329000001_fix_ex_dividend_date_type.sql
+++ b/supabase/migrations/20240329000001_fix_ex_dividend_date_type.sql
@@ -1,0 +1,20 @@
+-- Fix ex_dividend_date column type to prevent timezone errors
+-- This migration converts the column from TIMESTAMP WITH TIME ZONE to DATE
+
+DO $$ 
+BEGIN
+    -- Check if the column exists and is TIMESTAMP WITH TIME ZONE
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'securities' 
+        AND column_name = 'ex_dividend_date' 
+        AND data_type = 'timestamp with time zone'
+    ) THEN
+        -- Convert the column to DATE type
+        ALTER TABLE securities ALTER COLUMN ex_dividend_date TYPE DATE USING ex_dividend_date::DATE;
+        
+        RAISE NOTICE 'Successfully converted ex_dividend_date column from TIMESTAMP WITH TIME ZONE to DATE';
+    ELSE
+        RAISE NOTICE 'ex_dividend_date column is already DATE type or does not exist';
+    END IF;
+END $$; 


### PR DESCRIPTION
- Add collapsible months to Dividend Calendar, expanding only the current month by default
- Filter out Cash securities from all dividend-related calculations and calendar displays
- Add robust error boundary and defensive checks to Dividend Calendar to prevent UI crashes
- Deduplicate events in Dividend Timeline across portfolios; show each company’s event only once
- Limit Dividend Timeline to the next 5 unique events for a concise dashboard view
- Implement smart caching for dividend data: only refresh when stale, during market hours, or near ex-dividend dates
- Add “Smart Refresh” button with proper icon spacing; remove “Force Refresh” for a cleaner UI
- Refactor button text and spacing for consistency and clarity
- Various bug fixes, error handling improvements, and UI polish